### PR TITLE
Add heterogenous multi geometry support to KML

### DIFF
--- a/lib/decoders/kml.js
+++ b/lib/decoders/kml.js
@@ -7,7 +7,10 @@
 import _ from 'underscore';
 import expat from 'node-expat';
 import es from 'event-stream';
-import {Transform} from 'stream';
+import {
+  Transform
+}
+from 'stream';
 import {
   types
 }
@@ -35,6 +38,82 @@ var util = {
     return state;
   },
 
+  newFeature: () => {
+    return {};
+  },
+
+
+  /**
+   * So this is kind of weird:
+   * KML allows heterogenous geometries..
+   *   * not only within a file
+   *   * not only within a folder
+   *   * but also within a MultiGeometry tag!
+   *
+   * So this means that if we're in a Placemark.*.MultiGeometry tag,
+   * we need to be able to emit new N features into the feature stream,
+   * not just one.
+   *
+   * This is why all the event handlers need to return the state
+   * and an *array* of all geometries geometries, to be emitted into
+   * the geature stream, and not just a single geometry, because
+   * a placemark doesn't map 1:1 onto Socrata rows within a dataset
+   *
+   * So if we're in a MultiGeometry tag, and we see 2 points, like this:
+   * <MultiGeometry>
+   *   <Point>...</Point>
+   *   <Point>...</Point>
+   * </MultiGeometry>
+   *
+   * then when we encounter the 2nd point,
+   * we already have a feature in state.features that matches this type,
+   * so it gets appended as a point within a multipoint type object
+   *
+   * If we're in a MultiGeometry tag, and we see a line and point like this:
+   * <MultiGeometry>
+   *   <Point>...</Point>
+   *   <Line>...</Line>
+   * </MultiGeometry>
+   *
+   * Then when we encounter the line, it won't match any existing feature
+   * in the state.features list, so we clone the properties from an
+   * existing feature and build the coordinates for it, and then
+   * add it to the state.features list
+   *
+   * Recap:
+   *   * We have a schema, which just a suggestion of what type things might be
+   *   * We have folders, which is just a suggestion of logical groupings
+   *   * We have MultiGeometry, which is just a suggestion of shape groups
+   *
+   * So KML is the  ¯\_(ツ)_/¯ of geo formats
+   */
+  setOrCloneFeature: (state, kind, coordinateMerger) => {
+    var aFeature = state.features.find((feature) => {
+      return !feature[GEOM_NAME] || (feature[GEOM_NAME].type === kind);
+    });
+    if (aFeature) {
+      aFeature[GEOM_NAME] = aFeature[GEOM_NAME] || {};
+      aFeature[GEOM_NAME].type = kind;
+      aFeature[GEOM_NAME].coordinates = coordinateMerger(aFeature, state);
+    } else {
+      let clone = _.clone(state.features[0]);
+      clone[GEOM_NAME] = {};
+      clone[GEOM_NAME].type = kind;
+      clone[GEOM_NAME].coordinates = coordinateMerger(clone, state);
+      state.features.push(clone);
+    }
+    return state;
+  },
+
+  mergeSingleGeom: (_feature, state) => {
+    return state.coordinates;
+  },
+
+  mergeMultiGeom: (feature, state) => {
+    var coords = (feature[GEOM_NAME].coordinates || [])
+    coords.push(state.coordinates);
+    return coords;
+  },
 
   'int': [parseInt, 'number'],
   'float': [parseFloat, 'number'],
@@ -75,101 +154,97 @@ var coordParse = {
 var startElement = {
 
   'document.folder': (state, attrs) => {
-    return [state, false];
+    return [state, []];
   },
 
   'schema.simplefield': (state, attrs) => {
-    return [util.pushSchema(state, attrs), false];
+    return [util.pushSchema(state, attrs), []];
   },
 
   'placemark.name': (state, attrs) => {
     state.attr = 'name';
-    return [state, false];
+    return [state, []];
   },
 
   'placemark.description': (state, attrs) => {
     state.attr = 'description';
-    return [state, false];
+    return [state, []];
   },
 
   'placemark.extendeddata.schemadata.simpledata': (state, attrs) => {
     state.attr = attrs.name;
-    return [state, false];
+    return [state, []];
   }
 };
 
 
 var endElement = {
   'placemark': (state) => {
-    let f = state.feature;
-    return [state, f];
+    return [state, state.features];
   },
 
   'placemark.extendeddata.schemadata.simpledata': (state) => {
-    state.feature[state.attr] = state.attrValue;
-    return [state, false];
+    state.features = state.features.map((feature) => {
+      feature[state.attr] = state.attrValue;
+      return feature;
+    });
+    return [state, []];
   },
 
 
   //geometry
   'point.coordinates': (state) => {
     state.coordinates = coordParse.decode0(state.attrValue);
-    return [state, false];
+    return [state, []];
   },
 
   'point': (state) => {
-    state.feature[GEOM_NAME].type = 'point';
-    state.feature[GEOM_NAME].coordinates = state.coordinates;
-    return [state, false];
+    state = util.setOrCloneFeature(state, 'point', util.mergeSingleGeom);
+    return [state, []];
   },
 
   'multigeometry.point': (state) => {
-    state.feature[GEOM_NAME].type = 'multipoint';
-    state.feature[GEOM_NAME].coordinates.push(state.coordinates);
-    return [state, false];
+    state = util.setOrCloneFeature(state, 'multipoint', util.mergeMultiGeom);
+    state.coordinates = [];
+    return [state, []];
   },
-
 
   'linestring.coordinates': (state) => {
     state.coordinates = coordParse.decode1(coordParse.toSegments(state.attrValue));
-    return [state, false];
+    return [state, []];
   },
 
-  'linestring':(state) => {
-    state.feature[GEOM_NAME].type = 'linestring';
-    state.feature[GEOM_NAME].coordinates = state.coordinates;
-    return [state, false];
+  'linestring': (state) => {
+    state = util.setOrCloneFeature(state, 'linestring', util.mergeSingleGeom);
+    return [state, []];
   },
 
-  'multigeometry.linestring':(state) => {
-    state.feature[GEOM_NAME].type = 'multilinestring';
-    state.feature[GEOM_NAME].coordinates.push(state.coordinates);
-    return [state, false];
+  'multigeometry.linestring': (state) => {
+    state = util.setOrCloneFeature(state, 'multilinestring', util.mergeMultiGeom);
+    state.coordinates = [];
+    return [state, []];
   },
-
 
   'polygon.outerboundaryis.*.coordinates': (state) => {
     state.coordinates.push(coordParse.decode1(coordParse.toSegments(state.attrValue)));
-    return [state, false];
+    return [state, []];
   },
 
   'polygon.innerboundaryis.*.coordinates': (state) => {
     state.coordinates.push(coordParse.decode1(coordParse.toSegments(state.attrValue)));
-    return [state, false];
+    return [state, []];
   },
 
-  'polygon':(state) => {
-    state.feature[GEOM_NAME].type = 'polygon';
-    state.feature[GEOM_NAME].coordinates = state.coordinates;
+  'polygon': (state) => {
+    state = util.setOrCloneFeature(state, 'polygon', util.mergeSingleGeom);
     state.coordinates = [];
-    return [state, false];
+    return [state, []];
   },
 
-  'multigeometry.polygon':(state) => {
-    state.feature[GEOM_NAME].type = 'multipolygon';
-    state.feature[GEOM_NAME].coordinates.push(state.coordinates);
+  'multigeometry.polygon': (state) => {
+    state = util.setOrCloneFeature(state, 'multipolygon', util.mergeMultiGeom);
     state.coordinates = [];
-    return [state, false];
+    return [state, []];
   }
 
 };
@@ -179,7 +254,9 @@ var endElement = {
 class KML extends Transform {
 
   constructor() {
-    super({objectMode: true});
+    super({
+      objectMode: true
+    });
     this._parser = new expat.Parser("UTF-8");
     var out = through((chunk) => {}, () => out.queue(null));
 
@@ -192,27 +269,31 @@ class KML extends Transform {
       attr: '',
       attrValue: '',
       coordinates: [],
-      feature: this._newFeature()
+      features: this._newFeatures()
     };
 
     this._parser.on('error', (error) => {
-      this.emit('error', new Error(`XML Parse error: ${error.toString()}`));
+      this.emit('error', new Error(`XML Parse error: ${error.stack}`));
     });
 
     events.forEach((ev) => {
       this._parser.on(ev, (name, attrs) => {
         //something weird is happening with arguments in () => {}  ;_;
         //so name,attrs isn't necessarily an accurate name...
-        var [newState, feature] = this['_' + ev](state, name, attrs);
+        var [newState, features] = this['_' + ev](state, name, attrs);
 
-        if (feature) {
-          let row = toRow(
-            feature[GEOM_NAME], geomToSoQL, _.omit(feature, GEOM_NAME),
-            _.partial(this._propToSoQL, state.schema),
-            CRS
-          );
-          this.push(row);
-          newState.feature = this._newFeature();
+        if (features.length) {
+          let rows = features.map((feature) => {
+            return toRow(
+              feature[GEOM_NAME], geomToSoQL, _.omit(feature, GEOM_NAME),
+              _.partial(this._propToSoQL, state.schema),
+              CRS
+            );
+          });
+
+          rows.forEach(this.push.bind(this));
+
+          newState.features = this._newFeatures();
         }
         state = newState;
       }.bind(this));
@@ -220,7 +301,7 @@ class KML extends Transform {
   }
 
   static canDecode() {
-    return ['application/vnd.google-earth.kml+xml']
+    return ['application/vnd.google-earth.kml+xml'];
   }
 
   _getHandler(state, handlers) {
@@ -246,14 +327,14 @@ class KML extends Transform {
     var matching = this._getHandler(state, startElement);
     if (matching) return startElement[matching](state, attrs);
 
-    return [state, false];
+    return [state, []];
   }
 
   _endElement(state, name) {
     var matching = this._getHandler(state, endElement);
 
     //ugh
-    var result = [state, false];
+    var result = [state, []];
     if (matching) {
       result = endElement[matching](state, name);
     }
@@ -268,7 +349,7 @@ class KML extends Transform {
 
   _text(state, contents) {
     state.attrValue += contents;
-    return [state, false];
+    return [state, []];
   }
 
   _propToSoQL(schema, name, value) {
@@ -280,12 +361,8 @@ class KML extends Transform {
     return new types[soqlCtype](name, value);
   }
 
-  _newFeature() {
-    var f = {};
-    f[GEOM_NAME] = {
-      coordinates: []
-    };
-    return f;
+  _newFeatures() {
+    return [util.newFeature()];
   }
 
   _transform(chunk, encoding, done) {

--- a/lib/decoders/kmz.js
+++ b/lib/decoders/kmz.js
@@ -31,7 +31,7 @@ class KMZ extends Duplex {
   }
 
   static canDecode() {
-    return ['application/vnd.google-earth.kmz', 'application/octet-stream']
+    return ['application/vnd.google-earth.kmz']
   }
 
   write(chunk, encoding, done) {

--- a/lib/decoders/shapefile.js
+++ b/lib/decoders/shapefile.js
@@ -47,7 +47,7 @@ class Shapefile extends Duplex {
   }
 
   static canDecode() {
-    return ['application/zip'];
+    return ['application/zip', 'application/octet-stream'];
   }
 
   _fileGroup(extension, name) {
@@ -56,7 +56,8 @@ class Shapefile extends Duplex {
   }
 
   write(chunk, encoding, done) {
-    return this._zBuffer.write(chunk, encoding, done);
+    console.log("Writing shape feature", encoding);
+    return this._zBuffer.write(chunk, 'binary', done);
   }
 
   end() {
@@ -85,6 +86,7 @@ class Shapefile extends Duplex {
       }.bind(this);
 
       emitter.on('record', (record) => {
+        console.log("Shp record", record);
         this._onRecord(record, projection);
         readNext();
       }.bind(this));
@@ -115,12 +117,15 @@ class Shapefile extends Duplex {
   }
 
   _onBuffered() {
+    console.log("On buffered!")
     var extracted = [];
     yauzl.open(this._zName, (err, zipFile) => {
       if (err) return this.emit('error', err);
       zipFile.on('entry', (entry) => {
           zipFile.openReadStream(entry, (err, fstream) => {
             if (err) return this.emit('error', err);
+
+            console.log("Found", entry.fileName);
             var ext = path.extname(entry.fileName);
             var basename = path.basename(entry.fileName, ext);
             var extractedName = this._fileGroup(ext, basename);

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,8 +5,11 @@ import version from './services/version';
 import Spatial from './services/spatial';
 import Summary from './services/summary';
 
-
 function js(req, res, next) {
+  req.setEncoding('binary');
+  req.on('data', (chunk) => {
+    // console.log("chunk", typeof chunk) //TODO: log this
+  });
   if(!req.accepts('json')) {
     console.warn("non json accept header!");
 
@@ -15,15 +18,24 @@ function js(req, res, next) {
   next();
 }
 
+function logger(req, res, next) {
+  // console.log("Request started", req.url); //TODO: log this
+  // console.log("Request has content type", req.headers['content-type']) //TODO: log this
+
+  res.on('finish', () => {
+    // console.log("Request finished with", res.statusCode) //TODO: log this
+  });
+
+  next();
+}
 
 
 function router(config, app, zookeeper) {
   var spatial = new Spatial(zookeeper);
   var summary = new Summary();
-
-  app.get('/version', js, version.get);
-  app.post('/summary', js, summary.post.bind(summary));
-  app.post('/spatial', js, spatial.post.bind(spatial));
+  app.get('/version', js, logger, version.get);
+  app.post('/summary', js, logger, summary.post.bind(summary));
+  app.post('/spatial', js, logger, spatial.post.bind(spatial));
 }
 
-export default router
+export default router;

--- a/test/fixtures/points_and_lines_multigeom.kml
+++ b/test/fixtures/points_and_lines_multigeom.kml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Folder>
+      <name>OGRGeoJSON</name>
+      <Schema name="OGRGeoJSON" id="OGRGeoJSON">
+        <SimpleField name="a_string" type="string"/>
+      </Schema>
+      <Placemark>
+        <ExtendedData>
+          <SchemaData schemaUrl="#OGRGeoJSON">
+            <SimpleData name="a_string">first value</SimpleData>
+          </SchemaData>
+        </ExtendedData>
+        <MultiGeometry>
+          <Point>
+            <coordinates>102.0,0.5</coordinates>
+          </Point>
+          <LineString>
+            <coordinates>101,0 101,1</coordinates>
+          </LineString>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+  </Document>
+</kml>

--- a/test/kml.js
+++ b/test/kml.js
@@ -16,12 +16,12 @@ describe('unit :: kml decoder turns things into SoQLTypes', function() {
     fixture('malformed_kml.kml')
       .pipe(new KML())
       .on('error', (err) => {
-        expect(err.toString()).to.contain("mismatched tag");
+        expect(err.toString()).to.contain("XML Parse error");
         onDone();
       });
   });
 
-  it('can turn simple points to SoQLPoint', function(onDone) {
+  it('can turn kml simple points to SoQLPoint', function(onDone) {
     var expectedValues = [
       [{
           "type": "Point",
@@ -54,8 +54,8 @@ describe('unit :: kml decoder turns things into SoQLTypes', function() {
     var count = 0;
 
     fixture('simple_points.kml')
-    .pipe(kml)
-    .pipe(es.mapSync(function(thing) {
+      .pipe(kml)
+      .pipe(es.mapSync(function(thing) {
         let columns = thing.columns;
 
         expect(columns.map((c) => c.constructor.name)).to.eql([
@@ -74,7 +74,7 @@ describe('unit :: kml decoder turns things into SoQLTypes', function() {
       });
   });
 
-  it('can turn simple lines to SoQLLine', function(onDone) {
+  it('can turn kml simple lines to SoQLLine', function(onDone) {
 
     var expectedValues = [
       [{
@@ -113,43 +113,67 @@ describe('unit :: kml decoder turns things into SoQLTypes', function() {
     var count = 0;
 
     fixture('simple_lines.kml')
-    .pipe(kml)
-    .pipe(es.mapSync(function(thing) {
-      let columns = thing.columns;
-      expect(columns.map((c) => c.constructor.name)).to.eql([
-        'SoQLLine',
-        'SoQLText'
-      ]);
+      .pipe(kml)
+      .pipe(es.mapSync(function(thing) {
+        let columns = thing.columns;
+        expect(columns.map((c) => c.constructor.name)).to.eql([
+          'SoQLLine',
+          'SoQLText'
+        ]);
 
-      // console.log(columns.map((c) => c.value), expectedValues[count])
-      expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
+        // console.log(columns.map((c) => c.value), expectedValues[count])
+        expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
 
-      count++;
-    })).on('end', () => {
-      expect(count).to.equal(2);
-      onDone();
-    });
+        count++;
+      })).on('end', () => {
+        expect(count).to.equal(2);
+        onDone();
+      });
   });
 
-  it('can turn simple polys to SoQLPolygon', function(onDone) {
+  it('can turn kml simple polys to SoQLPolygon', function(onDone) {
     var expectedValues = [
       [{
-        "type": "Polygon",
-        "coordinates": [
-          [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
-          [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
-        ]
-       },
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [100.0, 0.0],
+              [101.0, 0.0],
+              [101.0, 1.0],
+              [100.0, 1.0],
+              [100.0, 0.0]
+            ],
+            [
+              [100.2, 0.2],
+              [100.8, 0.2],
+              [100.8, 0.8],
+              [100.2, 0.8],
+              [100.2, 0.2]
+            ]
+          ]
+        },
         "first value"
       ],
       [{
-        "type": "Polygon",
-        "coordinates": [
-          [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
-          [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
-        ]
-      },
-      "second value"
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [100.0, 0.0],
+              [101.0, 0.0],
+              [101.0, 1.0],
+              [100.0, 1.0],
+              [100.0, 0.0]
+            ],
+            [
+              [100.2, 0.2],
+              [100.8, 0.2],
+              [100.8, 0.8],
+              [100.2, 0.8],
+              [100.2, 0.2]
+            ]
+          ]
+        },
+        "second value"
       ]
     ];
 
@@ -157,127 +181,228 @@ describe('unit :: kml decoder turns things into SoQLTypes', function() {
     var kml = new KML();
     var count = 0;
     fixture('simple_polygons.kml')
-    .pipe(kml)
-    .pipe(es.mapSync(function(thing) {
-      let columns = thing.columns;
-      expect(columns.map((c) => c.constructor.name)).to.eql([
-        'SoQLPolygon',
-        'SoQLText'
-      ]);
+      .pipe(kml)
+      .pipe(es.mapSync(function(thing) {
+        let columns = thing.columns;
+        expect(columns.map((c) => c.constructor.name)).to.eql([
+          'SoQLPolygon',
+          'SoQLText'
+        ]);
 
-      expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
-      count++;
-    })).on('end', onDone);
+        expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
+        count++;
+      })).on('end', onDone);
   });
 
-  it('can turn simple points to SoQLMultiPoint', function(onDone) {
+  it('can turn kml simple multipoints to SoQLMultiPoint', function(onDone) {
     var expectedValues = [
       [{
-        "type": "MultiPoint",
-        "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
-      },
+          "type": "MultiPoint",
+          "coordinates": [
+            [100.0, 0.0],
+            [101.0, 1.0]
+          ]
+        },
         "first value"
       ],
       [{
-        "type": "MultiPoint",
-        "coordinates": [ [101.0, 0.0], [101.0, 1.0] ]
-      },
-      "second value"
+          "type": "MultiPoint",
+          "coordinates": [
+            [101.0, 0.0],
+            [101.0, 1.0]
+          ]
+        },
+        "second value"
       ]
     ];
 
     var kml = new KML();
     var count = 0;
     fixture('simple_multipoints.kml')
-    .pipe(kml)
-    .pipe(es.mapSync(function(thing) {
-      let columns = thing.columns;
-      expect(columns.map((c) => c.constructor.name)).to.eql([
-        'SoQLMultiPoint',
-        'SoQLText'
-      ]);
-
-      expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
-      count++;
-    })).on('end', onDone);
+      .pipe(kml)
+      .pipe(es.mapSync(function(thing) {
+        let columns = thing.columns;
+        expect(columns.map((c) => c.constructor.name)).to.eql([
+          'SoQLMultiPoint',
+          'SoQLText'
+        ]);
+        expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
+        count++;
+      })).on('end', onDone);
   });
 
-  it('can turn simple points to SoQLMultiLine', function(onDone) {
+  it('can turn kml simple multilines to SoQLMultiLine', function(onDone) {
     var expectedValues = [
       [{
-        "type": "MultiLineString",
-        "coordinates": [
-            [ [100.0, 0.0], [101.0, 1.0] ],
-            [ [102.0, 2.0], [103.0, 3.0] ]
-        ]
-      },
+          "type": "MultiLineString",
+          "coordinates": [
+            [
+              [100.0, 0.0],
+              [101.0, 1.0]
+            ],
+            [
+              [102.0, 2.0],
+              [103.0, 3.0]
+            ]
+          ]
+        },
         "first value"
       ],
       [{
-        "type": "MultiLineString",
-        "coordinates": [
-            [ [101.0, 0.0], [102.0, 1.0] ],
-            [ [102.0, 2.0], [103.0, 3.0] ]
-        ]
-      },
-      "second value"
+          "type": "MultiLineString",
+          "coordinates": [
+            [
+              [101.0, 0.0],
+              [102.0, 1.0]
+            ],
+            [
+              [102.0, 2.0],
+              [103.0, 3.0]
+            ]
+          ]
+        },
+        "second value"
       ]
     ];
 
     var kml = new KML();
     var count = 0;
     fixture('simple_multilines.kml')
-    .pipe(kml)
-    .pipe(es.mapSync(function(thing) {
-      let columns = thing.columns;
-      expect(columns.map((c) => c.constructor.name)).to.eql([
-        'SoQLMultiLine',
-        'SoQLText'
-      ]);
+      .pipe(kml)
+      .pipe(es.mapSync(function(thing) {
+        let columns = thing.columns;
+        expect(columns.map((c) => c.constructor.name)).to.eql([
+          'SoQLMultiLine',
+          'SoQLText'
+        ]);
 
-      expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
-      count++;
-    })).on('end', onDone);
+        expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
+        count++;
+      })).on('end', onDone);
   });
 
-  it('can turn simple points to SoQLMultiPolygon', function(onDone) {
+  it('can turn kml simple multipolys to SoQLMultiPolygon', function(onDone) {
     var expectedValues = [
       [{
-        "type": "MultiPolygon",
-        "coordinates": [
-          [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
-          [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
-           [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [102.0, 2.0],
+                [103.0, 2.0],
+                [103.0, 3.0],
+                [102.0, 3.0],
+                [102.0, 2.0]
+              ]
+            ],
+            [
+              [
+                [100.0, 0.0],
+                [101.0, 0.0],
+                [101.0, 1.0],
+                [100.0, 1.0],
+                [100.0, 0.0]
+              ],
+              [
+                [100.2, 0.2],
+                [100.8, 0.2],
+                [100.8, 0.8],
+                [100.2, 0.8],
+                [100.2, 0.2]
+              ]
+            ]
           ]
-      },
+        },
         "first value"
       ],
       [{
-        "type": "MultiPolygon",
-        "coordinates": [
-          [[[103.0, 2.0], [102.0, 2.0], [103.0, 3.0], [102.0, 3.0], [103.0, 2.0]]],
-          [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
-           [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [103.0, 2.0],
+                [102.0, 2.0],
+                [103.0, 3.0],
+                [102.0, 3.0],
+                [103.0, 2.0]
+              ]
+            ],
+            [
+              [
+                [100.0, 0.0],
+                [101.0, 0.0],
+                [101.0, 1.0],
+                [100.0, 1.0],
+                [100.0, 0.0]
+              ],
+              [
+                [100.2, 0.2],
+                [100.8, 0.2],
+                [100.8, 0.8],
+                [100.2, 0.8],
+                [100.2, 0.2]
+              ]
+            ]
           ]
-      },
-      "second value"
+        },
+        "second value"
       ]
     ];
 
     var kml = new KML();
     var count = 0;
     fixture('simple_multipolygons.kml')
-    .pipe(kml)
-    .pipe(es.mapSync(function(thing) {
-      let columns = thing.columns;
-      expect(columns.map((c) => c.constructor.name)).to.eql([
-        'SoQLMultiPolygon',
-        'SoQLText'
-      ]);
+      .pipe(kml)
+      .pipe(es.mapSync(function(thing) {
+        let columns = thing.columns;
+        expect(columns.map((c) => c.constructor.name)).to.eql([
+          'SoQLMultiPolygon',
+          'SoQLText'
+        ]);
 
-      expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
-      count++;
+        expect(columns.map((c) => c.value)).to.eql(expectedValues[count]);
+        count++;
 
-    })).on('end', onDone);
+      })).on('end', onDone);
+  });
+
+
+  it('can turn kml multi geometry heterogenous shapes into SoQL', function(onDone) {
+
+    var kml = new KML();
+    var things = [];
+
+    var pointExpected = [{
+        "type": "MultiPoint",
+        "coordinates": [[
+          102.0,
+          0.5
+        ]]
+      },
+      "first value"
+    ]
+
+
+    var lineExpected = [{
+        "type": "MultiLineString",
+        "coordinates": [[
+          [101.0, 0.0],
+          [101.0, 1.0]
+        ]]
+      },
+      "first value"
+    ]
+
+    fixture('points_and_lines_multigeom.kml')
+      .pipe(kml)
+      .pipe(es.mapSync((thing) => things.push(thing)))
+      .on('end', () => {
+        var [t0, t1] = things;
+
+        expect(t0.columns.map((c) => c.value)).to.eql(pointExpected);
+        expect(t1.columns.map((c) => c.value)).to.eql(lineExpected);
+
+        onDone();
+      });
   });
 });

--- a/test/kmz.js
+++ b/test/kmz.js
@@ -38,7 +38,7 @@ describe('unit :: kmz decoder turns things into SoQLTypes', function() {
     fixture('malformed_kmz.kmz')
       .pipe(kmzDecoder())
       .on('error', (err) => {
-        expect(err.toString()).to.contain("mismatched tag");
+        expect(err.toString()).to.contain("XML Parse error");
         onDone();
       });
   });


### PR DESCRIPTION
* Previous implementation assumed homogenous
  collections in the MultiGeometry tag,
  which is not a reasonable assumption since
  KML allows you to do anything your heart desires.
* Added a point_and_line test in the test/kml.js
  suite for this case.
* All the parsing handlers now return a tuple
  *ahem array* of the state and N features to
  emit on the stream, rather than a singel feature
  to go on the stream. This allows emitting
  different typed features when we're within
  a multigeometry.
* Things are turned into multi* shape objects if
  they exist within a multigeometry, even if there
  is one. This tradeoff reduces extra complexity.