### PR TITLE
Cleanup on import failure

### DIFF
--- a/lib/decoders/transform.js
+++ b/lib/decoders/transform.js
@@ -1,4 +1,7 @@
-import {types} from '../soql/mapper';
+import {
+  types
+}
+from '../soql/mapper';
 import SoQLNull from '../soql/null';
 import logger from '../util/logger';
 
@@ -29,9 +32,9 @@ function geoJsToSoQL(feature, crs) {
 
 
 function propToSoQL(name, value) {
-  if(value === null) return new SoQLNull(name);
+  if (value === null) return new SoQLNull(name);
   var t = types[typeof value];
-  if(!t) {
+  if (!t) {
     logger.warn(`Invalid property ${name} type: ${typeof value} ${value}`);
     return false;
   }
@@ -39,7 +42,7 @@ function propToSoQL(name, value) {
 }
 
 function geomToSoQL(geom) {
-  if(geom === null) return new SoQLNull('the_geom');
+  if (geom === null) return new SoQLNull('the_geom');
   var ctype = geom.type.toLowerCase();
   var t = types[ctype];
   if (!t) {
@@ -54,12 +57,17 @@ function toRow(geometry, geomToSoQL, properties, propToSoQL, crs) {
 
   var soqlProps = [];
   if (properties) {
-    soqlProps = Object.keys(properties).map(function(name) {
-      return propToSoQL(name, properties[name]);
-    });
+    for (var k in properties) {
+      soqlProps.push(propToSoQL(k, properties[k]));
+    }
   }
 
-  return {columns: [soqlGeom].concat(soqlProps), crs: crs};
+  return {
+    columns: [soqlGeom].concat(soqlProps),
+    crs: crs
+  };
 }
 
-export {toRow as toRow, geomToSoQL as geomToSoQL, propToSoQL as propToSoQL, geoJsToSoQL as geoJsToSoQL};
+export {
+  toRow as toRow, geomToSoQL as geomToSoQL, propToSoQL as propToSoQL, geoJsToSoQL as geoJsToSoQL
+};

--- a/lib/services/spatial.js
+++ b/lib/services/spatial.js
@@ -21,25 +21,30 @@ class SpatialService {
     this._zk = zookeeper;
   }
 
+  _destroyLayers(fourfours, core, cb) {
+    return async.map(fourfours, core.destroy.bind(core), (err, destroyResponses) => {
+      return cb(err, destroyResponses);
+    });
+  }
 
   _createLayers(req, res, core, layers) {
     async.map(layers, core.create.bind(core), (err, datasetResponses) => {
       //failed to get upstream from zk or create request failed
       if (err) return res.status(err.statusCode).send(err.body);
-      return this._createColumns(req, res, core, _.zip(layers, datasetResponses));
+      return this._createColumns(req, res, core, layers, datasetResponses);
     });
   }
 
 
-  _createColumns(req, res, core, datasets) {
-    var colSpecs = _.flatten(datasets.map(([layer, dataset]) => {
-      var fourfour = dataset.body.id;
+  _createColumns(req, res, core, layers, datasetResponses) {
+    var fourfours = datasetResponses.map((dr) => dr.body.id);
+    var colSpecs = _.flatten(_.zip(layers, fourfours).map(([layer, fourfour]) => {
       return layer.columns.map((col) => [fourfour, col]);
     }), true);
 
     return async.map(colSpecs, core.addColumn.bind(core), (err, colResponses) => {
-      if (err) return res.status(err.statusCode).send(err.body);
-      return this._upsertLayers(req, res, core, datasets);
+      if (err) return this._destroyLayers(fourfours, core, () => res.status(err.statusCode).send(err.body));
+      return this._upsertLayers(req, res, core, layers, fourfours);
     });
   }
 
@@ -55,21 +60,26 @@ class SpatialService {
     }, new BBox());
   }
 
-
-  _upsertLayers(req, res, core, datasets) {
-    var upsertSpecs = datasets.map(([layer, ds]) => [layer, ds.body.id]);
+  //this is confusing - make it not confusing
+  _upsertLayers(req, res, core, layers, fourfours) {
+    var upsertSpecs = _.zip(layers, fourfours);
     req.log.debug(`upsert specs ${upsertSpecs}`);
+
+    var fail = (cb) => {
+      this._destroyLayers(fourfours, core, cb);
+    };
     //this is a little different than the two preceding core calls. core.upsert
     //just sets up the request, so the callback will
     //return to the finish callback a list of *open* requests, rather than completed
     //requests, as well as the corresponding layer. Then we need to pipe the
     //layer's scratch file to the open request
     return async.map(upsertSpecs, core.upsert.bind(core), (err, upsert) => {
-      if(err) return res.status(503).send(err);
+      if(err) return fail(() => res.status(503).send(err));
 
       return async.map(upsert, ([[layer, fourfour], upsertBuilder], cb) => {
         req.log.info(`Starting upsert to ${fourfour}`);
-        layer.pipe(upsertBuilder())
+        var upsertRequest = upsertBuilder();
+        layer.pipe(upsertRequest)
           .on('response', (upsertResponse) => {
             req.log.info(`Got upsert response ${upsertResponse.statusCode}`);
             //bb hack to match the rest of the flow
@@ -95,7 +105,7 @@ class SpatialService {
           });
 
       }, (err, upsertResponses) => {
-        if (err) return res.status(err.statusCode || 503).send(err.body);
+        if (err) return fail(() => res.status(err.statusCode || 503).send(err.body));
 
         var layerResults = upsertResponses.map(([
           [layer, fourfour], response
@@ -110,9 +120,7 @@ class SpatialService {
           layers: layerResults
         };
 
-        //logthis
         req.log.info(`Successfully upserted ${layerResults.map((l) => l.uid)} with ${layerResults.map((l) => l.create)} features`);
-
         return res.status(200).send(upsertResult);
       });
     });

--- a/lib/upstream/core.js
+++ b/lib/upstream/core.js
@@ -91,6 +91,19 @@ class Core {
     });
   }
 
+  destroy(fourfour, onComplete) {
+    return this._url((err, url) => {
+      if (err) return onComplete(err);
+      request.del({
+          url: `${url}/views/${fourfour}`,
+          headers: this._headers(),
+          json: true
+        })
+        .on('response', this._onResponseStart(onComplete))
+        .on('error', this._onErrorResponse(onComplete));
+    });
+  }
+
   create(layer, onComplete) {
     return this._url((err, url) => {
       if (err) return onComplete(err);

--- a/test/unit/summary.js
+++ b/test/unit/summary.js
@@ -82,7 +82,7 @@ describe('summary service', () => {
         //the request tries to send the request twice, which was
         //happening for streams that didn't bind to the correct
         //events
-        setTimeout(onDone, 50);
+        setTimeout(onDone, 10);
       });
   });
 
@@ -109,7 +109,7 @@ describe('summary service', () => {
         //the request tries to send the request twice, which was
         //happening for streams that didn't bind to the correct
         //events
-        setTimeout(onDone, 50);
+        setTimeout(onDone, 10);
       });
   });
 


### PR DESCRIPTION
* If the upsert fails, or column creation fails, clean up
  the datasets that were initially created to put the data
  into.
* Added tests, added delete endpoint in mock-core to mirror
  core irl