### PR TITLE
Replace shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,21 @@ do a single, full test run with `npm test`
 
 Smoke tests are tests on real datasets that will take considerably longer to run, so you don't
 want to be running them when developing. If you want to add a smoke test, add it to the `test/smoke` directory.
+
+## using
+
+* we define `shapeblob` as one of {shape archive, kmz, kml, geojson}
+* Content-Types
+  * KML content-type must be application/vnd.google-earth.kml+xml
+  * KMZ content-type must be application/vnd.google-earth.kmz
+  * geoJSON content-type must be application/json
+  * shapefile content-type must be application/zip
+
+
+| Method | Endpoint   | Payload | Content-Type | Description              | Response |
+| ------ | ---------- | ------- | ------------ |  ----------------------- | -------- |
+| `GET`  | `/version` | `none`  | `anything `  | get the service version  | version as json |
+| `POST` | `/summary` | `shapeblob` | must correspond to payload | create a summary of the blob | summary as json |
+| `POST` | `/spatial` | `shapeblob` | must correspond to payload | create a new dataset | upsert result as json |
+| `PUT`  | `/spatial/fbf0,fbf1,...,fbfn` | `shapeblob` | must correspond to payload | replace a dataset, where layers parsed from the dataset will replace the layer uuids passed in via the URL | upsert result as json |
+

--- a/lib/decoders/layer.js
+++ b/lib/decoders/layer.js
@@ -39,6 +39,9 @@ const WGS84 = '+proj=longlat +ellps=WGS84 +no_defs';
 
 
 class Layer extends Duplex {
+  static get EMPTY() {
+    return '__empty__';
+  }
 
   constructor(columns, position, disk, spec) {
     if (position === undefined) throw new Error("Need a layer index!");
@@ -75,6 +78,15 @@ class Layer extends Duplex {
 
   get name() {
     return this._spec.name || `layer_${this._position}`;
+  }
+
+  get uid() {
+    return this._spec.uid || Layer.EMPTY;
+  }
+
+  set uid(uid) {
+    this._spec.uid = uid;
+    return this;
   }
 
   belongsIn(soqlRow) {

--- a/lib/decoders/layer.js
+++ b/lib/decoders/layer.js
@@ -40,7 +40,7 @@ const WGS84 = '+proj=longlat +ellps=WGS84 +no_defs';
 
 class Layer extends Duplex {
 
-  constructor(columns, position, disk) {
+  constructor(columns, position, disk, spec) {
     if (position === undefined) throw new Error("Need a layer index!");
     super();
     this._position = position;
@@ -49,6 +49,7 @@ class Layer extends Duplex {
     this._count = 0;
     this._crsMap = {};
     this._projectTo = srs.parse(WGS84);
+    this._spec = spec || {};
 
     this._bbox = new BBox();
 
@@ -73,7 +74,7 @@ class Layer extends Duplex {
   }
 
   get name() {
-    return `layer_${this._position}`;
+    return this._spec.name || `layer_${this._position}`;
   }
 
   belongsIn(soqlRow) {

--- a/lib/decoders/merger.js
+++ b/lib/decoders/merger.js
@@ -29,7 +29,7 @@ import logger from '../util/logger';
 
 const DEFAULT_CRS = "urn:ogc:def:crs:OGC:1.3:CRS84";
 
-function getOrCreateLayer(layers, soqlRow, disk) {
+function getOrCreateLayer(layers, soqlRow, disk, spec) {
   var columns = soqlRow.columns;
   var layer = layers.find((layer) => layer.belongsIn(columns));
   if (!layer) {
@@ -40,21 +40,21 @@ function getOrCreateLayer(layers, soqlRow, disk) {
         t = types.string;
       }
       return new t(soqlValue.rawName);
-    }), layers.length, disk);
+    }), layers.length, disk, spec);
     layers.push(layer);
   }
   return [layers, layer];
 }
 
 class Merger extends Transform {
-  constructor(disk, throwaway) {
+  constructor(disk, specs, throwaway) {
     super({
       objectMode: true
     });
     if(!disk) throw new Error("Merger needs a disk");
+    this._specs = specs || [];
     this._throwaway = throwaway;
     this._disk = disk;
-
     this._layers = [];
     this._defaultCrs = DEFAULT_CRS;
   }
@@ -65,7 +65,8 @@ class Merger extends Transform {
       return done();
     }
 
-    var [newLayers, layer] = getOrCreateLayer(this._layers, chunk, this._disk);
+    var spec = this._specs[this._layers.length];
+    var [newLayers, layer] = getOrCreateLayer(this._layers, chunk, this._disk, spec);
     layer.write(chunk.crs, chunk.columns, this._throwaway);
     this._layers = newLayers;
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -10,6 +10,7 @@ function js(req, res, next) {
   if(!req.accepts('json')) {
     req.log.warn("Request does not accept application/json!");
   }
+  req.log.info(`Request ${req.method} ${req.url}`);
   res.setHeader('content-type', 'application/json');
   next();
 }
@@ -19,9 +20,11 @@ function router(config, app, zookeeper) {
   var spatial = new Spatial(zookeeper);
   var summary = new Summary(config);
 
-  app.get('/version', js, app.logger.request(), version.get);
-  app.post('/summary', js, app.logger.request(), summary.post.bind(summary));
-  app.post('/spatial', js, app.logger.request(), spatial.post.bind(spatial));
+  app.get('/version', app.logger.request(), js, version.get);
+  app.post('/summary', app.logger.request(), js, summary.post.bind(summary));
+  app.post('/spatial', app.logger.request(), js, spatial.create.bind(spatial));
+  app.put('/spatial/:fourfours', app.logger.request(), js, spatial.replace.bind(spatial));
+
 }
 
 export default router;

--- a/lib/services/spatial.js
+++ b/lib/services/spatial.js
@@ -50,7 +50,11 @@ class SpatialService {
    * @return {[BBox]}              m e g a  b b o x
    */
   _expandBbox(layerResults) {
-    return layerResults.reduce((wholeBbox, {layer: {bbox: bbox}}) => {
+    return layerResults.reduce((wholeBbox, {
+      layer: {
+        bbox: bbox
+      }
+    }) => {
       return wholeBbox.merge(bbox);
     }, new BBox());
   }
@@ -65,9 +69,11 @@ class SpatialService {
     //requests, as well as the corresponding layer. Then we need to pipe the
     //layer's scratch file to the open request
     return async.map(upsertSpecs, core.upsert.bind(core), (err, upsert) => {
-      if(err) return res.status(503).send(err);
+      if (err) return res.status(503).send(err);
 
-      return async.map(upsert, ([[layer, fourfour], upsertBuilder], cb) => {
+      return async.map(upsert, ([
+        [layer, fourfour], upsertBuilder
+      ], cb) => {
         req.log.info(`Starting upsert to ${fourfour}`);
         layer.pipe(upsertBuilder())
           .on('response', (upsertResponse) => {
@@ -111,7 +117,6 @@ class SpatialService {
         };
 
         req.log.info(`Successfully upserted ${layerResults.map((l) => l.uid)} with ${layerResults.map((l) => l.create)} features`);
-        req.log.info(`Returning ${JSON.stringify(upsertResult, null, 4)} to client`)
         return res.status(200).send(upsertResult);
       });
     });
@@ -142,14 +147,28 @@ class SpatialService {
     var [err, decoder] = getDecoder(req, disk);
     if(err) return res.status(400).send(err.toString());
 
-    req
-    .pipe(decoder)
-    .on('error', onErr)
-    .pipe(new Merger(disk))
-    .on('error', onErr)
-    .on('end', (layers) => {
-      return this._createLayers(req, res, core, layers);
+    //need to wrap the layer spec in a list if it's defined and is one element
+    var names = [];
+    if(_.isArray(req.query.names)) {
+      names = req.query.names;
+    } else if(!_.isUndefined(req.query.names)) {
+      names = [req.query.names];
+    }
+    var specs = names.map((name) => {
+      return {
+        name: name
+      };
     });
+    req.log.info(`Create layers according to ${JSON.stringify(specs)}`);
+
+    req
+      .pipe(decoder)
+      .on('error', onErr)
+      .pipe(new Merger(disk, specs, false))
+      .on('error', onErr)
+      .on('end', (layers) => {
+        return this._createLayers(req, res, core, layers);
+      });
   }
 }
 

--- a/lib/services/spatial.js
+++ b/lib/services/spatial.js
@@ -86,7 +86,11 @@ class SpatialService {
         var replacements = _.flatten(
           _.zip(layers, responses)
           .map(([layer, [response, isReplace]]) => {
-            layer.uid = response.body.id;
+            var newUid = response.body.id;
+            if(isReplace) {
+              req.log.info(`Going to replace ${layer.uid} with new copy ${newUid}`);
+            }
+            layer.uid = newUid;
             return [layer, isReplace];
           })
           .filter(([_layer, isReplace]) => isReplace)

--- a/lib/services/spatial.js
+++ b/lib/services/spatial.js
@@ -13,7 +13,9 @@ import {
   types
 }
 from '../soql/mapper';
+import Layer from '../decoders/layer';
 
+const MAX_PARALLEL = 4;
 
 class SpatialService {
   constructor(zookeeper) {
@@ -22,26 +24,112 @@ class SpatialService {
   }
 
 
+  _createOrReplace(core, layer) {
+    return (layer, cb) => {
+      if (layer.uid === Layer.EMPTY) {
+        return core.create(layer, (err, resp) => {
+          cb(err, [resp, false]);
+        });
+      }
+      return core.replace(layer, (err, resp) => {
+        cb(err, [resp, true]);
+      });
+    };
+  }
+
+  /**
+   * Helper for turning a list of layers into a flat list of
+   * [layerUid, column] tuples
+   */
+  _flatColSpecs(layers) {
+    return _.flatten(layers.map((layer) => {
+      return layer.columns.map((col) => [layer.uid, col]);
+    }), true);
+  }
+
+
   _createLayers(req, res, core, layers) {
-    async.map(layers, core.create.bind(core), (err, datasetResponses) => {
+    async.mapLimit(layers, MAX_PARALLEL, core.create.bind(core), (err, datasetResponses) => {
       //failed to get upstream from zk or create request failed
       if (err) return res.status(err.statusCode).send(err.body);
-      return this._createColumns(req, res, core, _.zip(layers, datasetResponses));
+      _.zip(layers, datasetResponses)
+        .forEach(([layer, response]) => layer.uid = response.body.id);
+      return this._createColumns(req, res, core, layers);
     });
   }
 
+  /**
+   * Replace the layers in core.
+   * This will
+   *   Create or replace the layers
+   *     create a layer if the id in the layer is __empty__
+   *     replace a layer if the id in the layer is a uid
+   *
+   *     These IDs are passed in from the client (core), which
+   *     ultimately is made up from the `blueprint`
+   *
+   *   Get the columns for each layer that resulted in a copy
+   *   of the schema to a new view (ie: a replace) and flatten that
+   *   into a list of [viewFourFour, columnId] tuples
+   *
+   *   Delete all those columns that were just returned, because we need
+   *   to re-create them as columns can be dropped or added
+   *
+   *   Resume the normal flow, as we now have a list of layers that have
+   *   been created in the datastore with an empty set of columns for each
+   *
+   */
+  _replaceLayers(req, res, core, layers) {
+    var createOrReplace = (layers, cb) => {
+      async.mapLimit(layers, MAX_PARALLEL, this._createOrReplace(core), (err, responses) => {
+        if (err) return cb(err);
+        var replacements = _.flatten(
+          _.zip(layers, responses)
+          .map(([layer, [response, isReplace]]) => {
+            layer.uid = response.body.id;
+            return [layer, isReplace];
+          })
+          .filter(([_layer, isReplace]) => isReplace)
+          .map(([layer, _isReplace]) => layer));
+        cb(false, replacements);
+      });
 
-  _createColumns(req, res, core, datasets) {
-    var colSpecs = _.flatten(datasets.map(([layer, dataset]) => {
-      var fourfour = dataset.body.id;
-      return layer.columns.map((col) => [fourfour, col]);
-    }), true);
-    //only make 3 requests in parallel. core will die if we do a bunch.
-    return async.mapLimit(colSpecs, 3, core.addColumn.bind(core), (err, colResponses) => {
+    };
+
+    var flatColumns = (replacements, cb) => {
+      async.mapLimit(replacements, MAX_PARALLEL, core.getColumns.bind(core), (err, responses) => {
+        if (err) return cb(err);
+        var colSpecs = _.flatten(
+          _.zip(replacements, responses).map(([layer, response]) => {
+            return response.body.map((col) => [layer.uid, col.id]);
+          }), true);
+        cb(false, colSpecs);
+      });
+    };
+
+    var deleteColumns = (colSpecs, cb) => {
+      async.mapLimit(colSpecs, MAX_PARALLEL, core.deleteColumn.bind(core), (err, responses) => {
+        if (err) return cb(err);
+        cb(false, layers);
+      });
+    };
+
+    async.seq(createOrReplace, flatColumns, deleteColumns)(layers, (err, layers) => {
       if (err) return res.status(err.statusCode).send(err.body);
-      return this._upsertLayers(req, res, core, datasets);
+      return this._createColumns(req, res, core, layers);
     });
   }
+
+
+  _createColumns(req, res, core, layers) {
+    var colSpecs = this._flatColSpecs(layers);
+    //only make MAX_PARALLEL requests in parallel. core will die if we do a bunch.
+    return async.mapLimit(colSpecs, MAX_PARALLEL, core.addColumn.bind(core), (err, colResponses) => {
+      if (err) return res.status(err.statusCode).send(err.body);
+      return this._upsertLayers(req, res, core, layers);
+    });
+  }
+
 
   /**
    * Take all the bounding boxes from the layers and make a bounding box
@@ -60,30 +148,24 @@ class SpatialService {
   }
 
 
-  _upsertLayers(req, res, core, datasets) {
-    var upsertSpecs = datasets.map(([layer, ds]) => [layer, ds.body.id]);
-    req.log.debug(`upsert specs ${upsertSpecs}`);
+  _upsertLayers(req, res, core, layers) {
     //this is a little different than the two preceding core calls. core.upsert
     //just sets up the request, so the callback will
     //return to the finish callback a list of *open* requests, rather than completed
     //requests, as well as the corresponding layer. Then we need to pipe the
     //layer's scratch file to the open request
-    return async.map(upsertSpecs, core.upsert.bind(core), (err, upsert) => {
+    return async.map(layers, core.upsert.bind(core), (err, upsert) => {
       if (err) return res.status(503).send(err);
 
-      return async.map(upsert, ([
-        [layer, fourfour], upsertBuilder
-      ], cb) => {
-        req.log.info(`Starting upsert to ${fourfour}`);
+      return async.map(upsert, ([layer, upsertBuilder], cb) => {
+        req.log.info(`Starting upsert to ${layer.uid}`);
         layer.pipe(upsertBuilder())
           .on('response', (upsertResponse) => {
             req.log.info(`Got upsert response ${upsertResponse.statusCode}`);
             //bb hack to match the rest of the flow
             core.bufferResponse((bufferedResponse) => {
               if (bufferedResponse.statusCode > 300) return cb(bufferedResponse);
-              return cb(false, [
-                [layer, fourfour], bufferedResponse
-              ]);
+              return cb(false, [layer, bufferedResponse]);
             })(upsertResponse);
           })
           .on('error', (err) => {
@@ -103,11 +185,9 @@ class SpatialService {
       }, (err, upsertResponses) => {
         if (err) return res.status(err.statusCode || 503).send(err.body);
 
-        var layerResults = upsertResponses.map(([
-          [layer, fourfour], response
-        ]) => {
+        var layerResults = upsertResponses.map(([layer, response]) => {
           return {
-            'uid': fourfour,
+            'uid': layer.uid,
             'layer': layer.toJSON()
           };
         });
@@ -122,7 +202,7 @@ class SpatialService {
     });
   }
 
-  post(req, res) {
+  _readShapeBlob(req, res, onEnd) {
     var auth = new CoreAuth(req);
     var core = new Core(auth, this._zk);
     var disk = new Disk(res);
@@ -144,21 +224,12 @@ class SpatialService {
     //If we can't get a decoder, then the user tried to import
     //an unsupported file, or set the content type incorrectly
     //on their header
-    var [err, decoder] = getDecoder(req, disk);
-    if(err) return res.status(400).send(err.toString());
+    var [decoderErr, decoder] = getDecoder(req, disk);
+    if (decoderErr) return res.status(400).send(decoderErr.toString());
 
-    //need to wrap the layer spec in a list if it's defined and is one element
-    var names = [];
-    if(_.isArray(req.query.names)) {
-      names = req.query.names;
-    } else if(!_.isUndefined(req.query.names)) {
-      names = [req.query.names];
-    }
-    var specs = names.map((name) => {
-      return {
-        name: name
-      };
-    });
+    var [mungeErr, specs] = this._mungeLayerSpecs(req);
+    if (mungeErr) return res.status(400).send(mungeErr.toString());
+
     req.log.info(`Create layers according to ${JSON.stringify(specs)}`);
 
     req
@@ -167,8 +238,40 @@ class SpatialService {
       .pipe(new Merger(disk, specs, false))
       .on('error', onErr)
       .on('end', (layers) => {
-        return this._createLayers(req, res, core, layers);
+        onEnd(core, layers);
       });
+  }
+
+  _mungeLayerSpecs(req) {
+    //need to wrap the layer spec in a list if it's defined and is one element
+    var names = [];
+    var uids = [];
+    if (_.isArray(req.query.names)) {
+      names = req.query.names;
+    } else if (!_.isUndefined(req.query.names)) {
+      names = [req.query.names];
+    }
+    var fourfours = (req.params.fourfours || '').split(',').filter((ff) => ff);
+    return [false, _.zip(names, fourfours).map(([name, uid]) => {
+      return {
+        name: name,
+        uid: uid
+      };
+    })];
+  }
+
+  create(req, res) {
+    req.log.info("Starting create of the dataset");
+    this._readShapeBlob(req, res, (core, layers) => {
+      return this._createLayers(req, res, core, layers);
+    });
+  }
+
+  replace(req, res) {
+    req.log.info("Starting replace of the dataset");
+    this._readShapeBlob(req, res, (core, layers) => {
+      return this._replaceLayers(req, res, core, layers);
+    });
   }
 }
 

--- a/lib/services/summary.js
+++ b/lib/services/summary.js
@@ -56,7 +56,7 @@ class SummaryService {
       req
       .pipe(decoder)
       .on('error', onErr)
-      .pipe(new Merger(disk, true))
+      .pipe(new Merger(disk, [], true))
       .on('error', onErr)
       .on('end', (layers) => {
         ok(layers.map((layer) => layer.toJSON()));

--- a/lib/upstream/core.js
+++ b/lib/upstream/core.js
@@ -1,6 +1,7 @@
 import request from 'request';
 import reduceStream from 'stream-reduce';
 import logger from '../util/logger';
+import Layer from '../decoders/layer';
 
 class CoreAuth {
   constructor(request) {
@@ -92,9 +93,13 @@ class Core {
   }
 
   create(layer, onComplete) {
+    if(layer.uid !== Layer.EMPTY) {
+      logger.warn(`Layer uid is not empty, layer uid is ${layer.uid}, cannot create layer in datastore!`);
+    }
     return this._url((err, url) => {
       if (err) return onComplete(err);
 
+      logger.info(`CreateDataset request to core`);
       request.post({
           url: `${url}/views?nbe=true`,
           headers: this._headers(),
@@ -108,11 +113,12 @@ class Core {
     });
   }
 
+
   replace(layer, onComplete) {
     return this._url((err, url) => {
       if (err) return onComplete(err);
 
-      logger.info(`CopySchema request for ${layer.uid} to core`);
+      logger.info(`CopySchema request for new layer to core`);
       request.post({
           url: `${url}/views/${layer.uid}/publication?method=copySchema`,
           headers: this._headers()

--- a/lib/upstream/core.js
+++ b/lib/upstream/core.js
@@ -108,6 +108,20 @@ class Core {
     });
   }
 
+  replace(layer, onComplete) {
+    return this._url((err, url) => {
+      if (err) return onComplete(err);
+
+      logger.info(`CopySchema request for ${layer.uid} to core`);
+      request.post({
+          url: `${url}/views/${layer.uid}/publication?method=copySchema`,
+          headers: this._headers()
+        })
+        .on('response', this._onResponseStart(onComplete))
+        .on('error', this._onErrorResponse(onComplete));
+    });
+  }
+
   addColumn(colSpec, onComplete) {
     var [fourfour, column] = colSpec;
     logger.info(`Add column ${fourfour} ${JSON.stringify(column.toJSON())} to core`);
@@ -126,19 +140,48 @@ class Core {
     });
   }
 
+  getColumns(layer, onComplete) {
+    return this._url((err, url) => {
+      if (err) return onComplete(err);
 
-  upsert(upsertSpec, onOpened) {
-    var [_layer, fourfour] = upsertSpec;
-    logger.info(`Upsert to core ${fourfour}`);
+      return request.get({
+          url: `${url}/views/${layer.uid}/columns`,
+          headers: this._headers()
+        })
+        .on('response', this._onResponseStart(onComplete))
+        .on('error', this._onErrorResponse(onComplete));
+    });
+  }
+
+  deleteColumn(colSpec, onComplete) {
+    var [viewId, colId] = colSpec;
+    logger.info(`Delete column ${viewId} ${colId} from core`);
+
+    return this._url((err, url) => {
+      if (err) return onComplete(err);
+
+      return request.del({
+          url: `${url}/views/${viewId}/columns/${colId}`,
+          headers: this._headers()
+        })
+        .on('response', this._onResponseStart(onComplete))
+        .on('error', this._onErrorResponse(onComplete));
+    });
+  }
+
+
+  upsert(layer, onOpened) {
+    logger.info(`Upsert to core ${layer.uid}`);
     return this._url((err, url) => {
       if (err) return onOpened(err);
+
       var upsertOpener = () => {
         return request.post({
-          url: `${url}/id/${fourfour}.json`,
+          url: `${url}/id/${layer.uid}.json`,
           headers: this._headers()
         });
       };
-      return onOpened(false, [upsertSpec, upsertOpener]);
+      return onOpened(false, [layer, upsertOpener]);
     });
   }
 }

--- a/test/services/mock-core.js
+++ b/test/services/mock-core.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
-import es from 'event-stream' ;
+import _ from 'underscore';
+import es from 'event-stream';
 
 class CoreMock {
   constructor(port) {
@@ -18,11 +19,67 @@ class CoreMock {
     app.use(/\/views$/, bodyParser.json());
     app.use(/.*columns$/, bodyParser.json());
 
+    app.post('/views/:uid/publication', function(req, res) {
+      this._history.push(req);
+      var hs = req.headers;
+      if (!hs.authorization || !hs['x-app-token'] || !hs['x-socrata-host']) {
+        return res.status(400).send(JSON.stringify({
+          error: 'headers'
+        }));
+      }
+
+
+      var view = {
+        "id": "qs32-qpt8",
+        "name": req.body.name,
+        "averageRating": 0,
+        "createdAt": 1446152737,
+        "downloadCount": 0,
+        "newBackend": false,
+        "numberOfComments": 0,
+        "oid": 913,
+        "publicationAppendEnabled": false,
+        "publicationGroup": 971,
+        "publicationStage": "unpublished",
+        "tableId": 971,
+        "totalTimesRated": 0,
+        "viewCount": 0,
+        "viewLastModified": 1446152737,
+        "viewType": "tabular",
+        "columns": [],
+        "owner": {
+          "id": "y6j7-unfr",
+          "displayName": "wat",
+          "emailUnsubscribed": false,
+          "profileLastModified": 1437685194,
+          "screenName": "wat",
+          "rights": ["create_datasets", "edit_others_datasets", "edit_sdp", "edit_site_theme", "moderate_comments", "manage_users", "chown_datasets", "edit_nominations", "approve_nominations", "feature_items", "federations", "manage_stories", "manage_approval", "change_configurations", "view_domain", "view_others_datasets", "edit_pages", "create_pages", "view_goals", "view_dashboards", "edit_goals", "edit_dashboards", "create_dashboards"],
+          "flags": ["admin"]
+        },
+        "query": {},
+        "rights": ["read", "write", "add", "delete", "grant", "add_column", "remove_column", "update_column", "update_view", "delete_view"],
+        "tableAuthor": {
+          "id": "y6j7-unfr",
+          "displayName": "wat",
+          "emailUnsubscribed": false,
+          "profileLastModified": 1437685194,
+          "screenName": "wat",
+          "rights": ["create_datasets", "edit_others_datasets", "edit_sdp", "edit_site_theme", "moderate_comments", "manage_users", "chown_datasets", "edit_nominations", "approve_nominations", "feature_items", "federations", "manage_stories", "manage_approval", "change_configurations", "view_domain", "view_others_datasets", "edit_pages", "create_pages", "view_goals", "view_dashboards", "edit_goals", "edit_dashboards", "create_dashboards"],
+          "flags": ["admin"]
+        },
+        "flags": ["default"]
+      };
+
+      res.status(200).send(JSON.stringify(view));
+    }.bind(this));
+
     app.post('/views', function(req, res) {
       this._history.push(req);
       var hs = req.headers;
       if (!hs.authorization || !hs['x-app-token'] || !hs['x-socrata-host']) {
-        return res.status(400).send(JSON.stringify({error: 'headers'}));
+        return res.status(400).send(JSON.stringify({
+          error: 'headers'
+        }));
       }
       var view = {
         "id": "qs32-qpt7",
@@ -68,6 +125,38 @@ class CoreMock {
       res.status(200).send(JSON.stringify(view));
     }.bind(this));
 
+
+    app.get('/views/:fourfour/columns', function(req, res) {
+      this._history.push(req);
+      var hs = req.headers;
+      if (!hs.authorization || !hs['x-app-token'] || !hs['x-socrata-host']) {
+        return res.status(400).send('headers');
+      }
+
+      var view = _.range(0, 2).map((i) => {
+        return {
+          "id": 3415 + i,
+          "position": i,
+          "tableColumnId": 3415 + i,
+          "format": {}
+        }
+      });
+
+
+      res.status(200).send(JSON.stringify(view));
+    }.bind(this));
+
+    app.delete('/views/:fourfour/columns/:colId', function(req, res) {
+      this._history.push(req);
+      var hs = req.headers;
+      if (!hs.authorization || !hs['x-app-token'] || !hs['x-socrata-host']) {
+        return res.status(400).send('headers');
+      }
+
+      res.status(200).send(JSON.stringify({}));
+    }.bind(this));
+
+
     app.post('/views/:fourfour/columns', function(req, res) {
       this._history.push(req);
       var hs = req.headers;
@@ -75,7 +164,7 @@ class CoreMock {
         return res.status(400).send('headers');
       }
 
-      if(!req.body.name || !req.body.dataTypeName || !req.body.fieldName) {
+      if (!req.body.name || !req.body.dataTypeName || !req.body.fieldName) {
         return res.status(400).send('body');
       }
 
@@ -125,7 +214,7 @@ class CoreMock {
   close() {
     try {
       return this._app.close();
-    } catch(e) {
+    } catch (e) {
       //already closed...heh
     }
   }

--- a/test/unit/core-client.js
+++ b/test/unit/core-client.js
@@ -15,15 +15,15 @@ describe('core client', function() {
   var mockCore;
   var mockZk;
   var port = 6668;
-  var url = `http://localhost:${port}`
+  var url = `http://localhost:${port}`;
 
   beforeEach(function(onDone) {
-    mockZk = new MockZKClient(port)
+    mockZk = new MockZKClient(port);
     mockZk.connect();
     mockZk.on('connected', function() {
       mockCore = new CoreService(port);
-      onDone()
-    })
+      onDone();
+    });
   });
 
   afterEach(function() {
@@ -38,7 +38,7 @@ describe('core client', function() {
         'x-app-token': 'test-token',
         'x-socrata-host': 'test-host',
       }
-    }
+    };
     var auth = new CoreAuth(request);
 
     expect(auth.host).to.eql('test-host');
@@ -53,13 +53,13 @@ describe('core client', function() {
         'x-app-token': 'test-token',
         'x-socrata-host': 'test-host',
       }
-    }
+    };
     var auth = new CoreAuth(request);
-    var core = new Core(auth, mockZk)
+    var core = new Core(auth, mockZk);
 
     core.create('my_layer', (err, res) => {
       expect(err.statusCode).to.equal(400);
-      onDone()
+      onDone();
     });
 
   });
@@ -72,19 +72,36 @@ describe('core client', function() {
         'x-app-token': 'test-token',
         'x-socrata-host': 'test-host',
       }
-    }
+    };
     var auth = new CoreAuth(request);
-    var core = new Core(auth, mockZk)
+    var core = new Core(auth, mockZk);
 
     core.create('my_layer', (err, res) => {
       if (err) throw new Error(`Got invalid status ${err.statusCode}`);
 
       expect(res.statusCode).to.equal(200);
-      expect(res.body.id).to.equal('qs32-qpt7')
-      onDone()
+      expect(res.body.id).to.equal('qs32-qpt7');
+      onDone();
     });
+  });
 
+  it("can make a replace request to core", function(onDone) {
+    var request = {
+      headers: {
+        'authorization': 'test-auth',
+        'x-app-token': 'test-token',
+        'x-socrata-host': 'test-host',
+      }
+    };
+    var auth = new CoreAuth(request);
+    var core = new Core(auth, mockZk);
 
+    core.replace('my_layer', (err, res) => {
+      if (err) throw new Error(`Got invalid status ${err.statusCode}`);
+
+      expect(res.statusCode).to.equal(200);
+      onDone();
+    });
   });
 
 

--- a/test/unit/merger.js
+++ b/test/unit/merger.js
@@ -37,7 +37,7 @@ var expect = chai.expect;
 
 function makeMerger() {
   var res = new EventEmitter();
-  return [new Merger(new Disk(res)), res];
+  return [new Merger(new Disk(res), []), res];
 }
 
 

--- a/test/unit/spatial.js
+++ b/test/unit/spatial.js
@@ -15,6 +15,7 @@ import {
 from 'events';
 import config from '../../lib/config';
 import service from '../../lib/service';
+import qs from 'querystring';
 
 var expect = chai.expect;
 
@@ -42,9 +43,10 @@ describe('spatial service', function() {
 
 
   it('can post geojson and it will make a create dataset request to core', function(onDone) {
+    var names = {names: ['A layer named foo']};
     fixture('simple_points.json')
       .pipe(request.post({
-        url: url + '/spatial',
+        url: url + `/spatial?${qs.stringify(names)}`,
         headers: {
           'Authorization': 'test-auth',
           'X-App-Token': 'app-token',
@@ -56,7 +58,7 @@ describe('spatial service', function() {
         expect(response.statusCode).to.equal(200);
         var createRequest = _.first(mockCore.history);
         expect(createRequest.body).to.eql({
-          name: 'layer_0'
+          name: 'A layer named foo'
         });
         onDone();
       });
@@ -87,25 +89,24 @@ describe('spatial service', function() {
   //so this results in a corrupt file on the other end.
   //this works via curl, so the problem is on the test side with the posting
   //of the fixture, rather than in express. GAH
-  // it('can post kmz points and it will do an upsert to core', function(onDone) {
-  //   bufferJs(fixture('simple_points.kmz')
-  //     .pipe(request.post({
-  //       url: url + '/spatial',
-  //       encoding: null,
-  //       binary: true,
-  //       headers: {
-  //         'Authorization': 'test-auth',
-  //         'X-App-Token': 'app-token',
-  //         'X-Socrata-Host': 'localhost:6668',
-  //         'Content-Type': 'application/vnd.google-earth.kmz',
-  //       }
-  //     })), (resp, buffered) => {
-  //       expect(resp.statusCode).to.equal(200);
-  //       expect(buffered.layers.length).to.equal(1);
-  //       expect(buffered.layers[0].created).to.equal(2);
-  //       onDone();
-  //     });
-  // });
+  it('can post kmz points and it will do an upsert to core', function(onDone) {
+    bufferJs(fixture('simple_points.kmz')
+      .pipe(request.post({
+        url: url + '/spatial',
+        encoding: null,
+        binary: true,
+        headers: {
+          'Authorization': 'test-auth',
+          'X-App-Token': 'app-token',
+          'X-Socrata-Host': 'localhost:6668',
+          'Content-Type': 'application/vnd.google-earth.kmz',
+        }
+      })), (resp, buffered) => {
+        expect(resp.statusCode).to.equal(200);
+        expect(buffered.layers.length).to.equal(1);
+        onDone();
+      });
+  });
 
 
   it('can post geojson and it will make a create columns request to core', function(onDone) {
@@ -156,9 +157,10 @@ describe('spatial service', function() {
   });
 
   it('can post single layer and it will upsert to core', function(onDone) {
+    var names = {names: ['Some Name', 'Another Name']};
     bufferJs(fixture('simple_points.json')
       .pipe(request.post({
-        url: url + '/spatial',
+        url: url + `/spatial?${qs.stringify(names)}`,
         headers: {
           'Authorization': 'test-auth',
           'X-App-Token': 'app-token',
@@ -181,7 +183,7 @@ describe('spatial service', function() {
             'layer': {
               "count": 2,
               "geometry": "point",
-              "name": "layer_0",
+              "name": "Some Name",
 
               "columns": [
                 {


### PR DESCRIPTION
* Replace shapefile 
  * Added PUT route in router
  * Added replace method in service/spatial.js
  * Added _replaceLayers which 
    * for any layers not in the blueprint, create them
    * for layers in the blueprint, create a working copy
      *  Delete the columns
    * For all the layers, create the columns and perform the upsert
* tests in `unit/spatial.js`
* Accept blueprint as query param for which view to use as the working copy
* Pass layer names through to core via url params
* Added tests in spatial service and merger
