### PR TITLE
Reconnect to zk

### DIFF
--- a/lib/upstream/zookeeper.js
+++ b/lib/upstream/zookeeper.js
@@ -14,9 +14,15 @@ class Zookeeper extends EventEmitter {
   constructor(conf) {
     super();
     this._conf = conf;
-    if(!this._conf) throw new Error("Zookeeper argument error!");
-    var [aZookeeperNode] = this._conf.zk;
+    if (!this._conf) throw new Error('Zookeeper argument error!');
+    this._init();
+  }
 
+  _init() {
+    logger.info('Initializing zookeeper client');
+    if(this._client) this._client.close();
+
+    var [aZookeeperNode] = this._conf.zk;
     this._client = zookeeper.createClient(aZookeeperNode);
 
     //proxy the underlying events onto this emitter
@@ -25,35 +31,55 @@ class Zookeeper extends EventEmitter {
       this._client.on(ev, _.partial(this.emit, ev).bind(this));
       this.on(ev, _.partial(this._logEvent, ev).bind(this));
     });
+
+    this._client.on('expired', this._onExpired.bind(this));
   }
 
   _logEvent(ev) {
     logger.info(`zookeeper client event: ${ev}`);
   }
 
+  _onExpired() {
+    logger.warn('Zookeeper disconnected! Retrying...');
+    this._init();
+    this.connect();
+  }
 
-  getCore(cb) {
+
+  _getCore(cb) {
     this._client.getChildren(CORE_PATH, (err, children) => {
-      if(err) return cb(err);
-      if(!children.length) return cb({
+      if (err) return cb(err);
+      if (!children.length) return cb({
         statusCode: 502,
-        body: "No core nodes registered in zookeeper"
+        body: 'No core nodes registered in zookeeper'
       });
       var chosen = children[Math.floor(Math.random() * children.length)];
       var instance = path.join(CORE_PATH, chosen);
       this._client.getData(instance, (err, buf) => {
-        if(err) return cb(err);
+        if (err) return cb(err);
         try {
           let entry = JSON.parse(buf.toString('utf-8'));
           //scheme isn't in the zk entry? what happens if we go ssl ¯\_(ツ)_/¯
           let scheme = 'http';
           let url = `${scheme}://${entry.address}:${entry.port}`;
           return cb(false, url);
-        } catch(err) {
+        } catch (err) {
           return cb(err);
         }
       });
     });
+  }
+
+  getCore(cb) {
+    logger.debug('Attempt to get core client');
+    if (this._client.getState() === zookeeper.State.SYNC_CONNECTED) {
+      return this._getCore(cb);
+    } else {
+      logger.warn(`State is currently ${this._client.getState()}, waiting for reconnect`);
+      this._client.once('connected', () => {
+        this._getCore(cb);
+      });
+    }
   }
 
   connect() {

--- a/lib/upstream/zookeeper.js
+++ b/lib/upstream/zookeeper.js
@@ -20,7 +20,7 @@ class Zookeeper extends EventEmitter {
 
   _init() {
     logger.info('Initializing zookeeper client');
-    if(this._client) this._client.close();
+    if (this._client) this._client.close();
 
     var [aZookeeperNode] = this._conf.zk;
     this._client = zookeeper.createClient(aZookeeperNode);


### PR DESCRIPTION
* when dealing with a large row, node blocks and the zk session
  expires. node-zookeeper-client doesn't have reconnect logic,
  so it has been added
* important to note that the `expired` state is a terminal
  state for the client, so once it has expired, the client
  needs to be torn down and a new one initialized