### PR TITLE
Memory stuff and cruft removal

### DIFF
--- a/lib/decoders/layer.js
+++ b/lib/decoders/layer.js
@@ -61,8 +61,6 @@ class Layer extends Duplex {
       this._out = disk.allocate(this._outName);
       this._out.write(scratchPrologue);
     }
-
-    this.bufferedRows = [];
   }
 
   toJSON() {
@@ -119,7 +117,7 @@ class Layer extends Duplex {
   }
 
   get defaultCrs() {
-    return this._defaultCrs;
+    return this._defaultCrs || this._projectTo;
   }
 
   get projections() {
@@ -202,26 +200,13 @@ class Layer extends Duplex {
     this._updateColumnTypes(soqlRow);
     this._count++;
     if (throwaway) {
-      if(done) done();
+      if (done) done();
       return;
     }
 
-    this.bufferedRows.push(soqlRow);
-    if (this.bufferedRows.length > config.spillRowsToDiskAfter) {
-      this._spillToDisk(done);
-    } else if (done) {
-      done();
-    }
-  }
-
-  _spillToDisk(done) {
-    this._out.write(this.bufferedRows.map((soql) => {
-      return this._scratchSeparator(this._count) + JSON.stringify(soql.map((r) => r.value));
-    }).join('\n'), null, () => {
-      this.bufferedRows = [];
-      if (done) done();
-    });
-    logger.debug(`Write ${this.count} to disk`);
+    this._out.write(
+      this._scratchSeparator(this._count) + JSON.stringify(soqlRow.map((r) => r.value)) + '\n',
+      null, done);
   }
 
   _scratchSeparator(index) {
@@ -233,9 +218,13 @@ class Layer extends Duplex {
   }
 
   close(cb) {
-    this._spillToDisk(() => {
-      this._out.write(scratchEpilogue);
-      this._out.on('finish', cb);
+    this._out.write(scratchEpilogue, null, () => {
+      this._out.on('finish', () => {
+        this.emit('readable');
+        //why is this not being set?
+        this._readableState.emittedReadable = true;
+        cb();
+      });
       this._out.end();
     });
   }
@@ -252,44 +241,49 @@ class Layer extends Duplex {
     });
   }
 
-  _getDefaultProjection() {
-    return this._defaultCrs || this._projectTo;
-  }
 
   _getProjectionFor(index) {
-    if (!this._crsMap[index]) return this._getDefaultProjection();
+    if (!this._crsMap[index]) return this.defaultCrs;
     return srs.parse(this._crsMap[index]);
   }
 
-  //TODO: this is specific to a particular upstream so it should not live in the layer
-  pipe(into) {
-    logger.info(`Starting pipe of ${this.name} ${this.uid}`);
-    var index = 0;
-    into.write(jsonPrologue);
 
-    return this.read()
-      .on('end', into.end.bind(into))
+  _startPushing() {
+    this._isPushing = true;
+    var projectTo = this._projectTo;
+    var index = 0;
+
+    this.push(jsonPrologue);
+    fs.createReadStream(this._outName)
+      .pipe(ldj.parse())
       .pipe(es.map((row, cb) => {
+        var soqlRow = _.zip(this.columns, row).map(([column, value]) => {
+          var soql = new types[column.ctype](column.rawName, value);
+          if (soql.isGeometry) {
+            let projection = this._getProjectionFor(index);
+            let geom = soql.reproject(projection, projectTo);
+            this._expandBbox(geom);
+            return geom;
+          }
+          return soql;
+        });
+
         var sep = this._jsonSeparator(index);
         var ep = '';
         index++;
         if (index === this._count) ep = jsonEpilogue;
 
-        var asSoda = row.reduce((acc, col) => {
+        var asSoda = soqlRow.reduce((acc, col) => {
           acc[col.name] = col.value;
           return acc;
         }, {});
 
         var rowString = sep + JSON.stringify(asSoda) + ep;
-        return cb(false, rowString);
-      }))
-      .on('error', (e) => {
-        //caller is reponsible for cleaning up the stream when
-        //an error happens
-        logger.error(`Layer ${this.name} ${this.uid} failed ${e} on row ${index}`);
-        into.emit('error', e);
-      })
-      .pipe(into);
+        this.push(rowString);
+        cb();
+      })).on('end', () => {
+        this.push(null);
+      });
   }
 
   /**
@@ -301,30 +295,12 @@ class Layer extends Duplex {
                  lies outside of the bbox. After all features have been
                  read then _bbox will encompass all of them
   */
-  read() {
-    logger.info(`Reading scratch file ${this._outName} into ${this.uid}`);
-    var projectTo = this._projectTo,
-      defaultCrs = this._defaultCrs,
-      index = 0;
-
-    var ee = new EventEmitter();
-
-    return fs.createReadStream(this._outName)
-      .pipe(ldj.parse())
-      .pipe(es.map((row, cb) => {
-        var soqlValue = _.zip(this.columns, row).map(([column, value]) => {
-          var soql = new types[column.ctype](column.rawName, value);
-          if (soql.isGeometry) {
-            let projection = this._getProjectionFor(index);
-            let geom = soql.reproject(projection, projectTo);
-            this._expandBbox(geom);
-            return geom;
-          }
-          return soql;
-        });
-        index++;
-        cb(false, soqlValue);
-      }));
+  _read() {
+    if (!this._readableState.emittedReadable && !this._isPushing) {
+      this.once('readable', this._startPushing.bind(this));
+    } else if (!this._isPushing) {
+      this._startPushing();
+    }
   }
 }
 

--- a/lib/decoders/layer.js
+++ b/lib/decoders/layer.js
@@ -221,8 +221,7 @@ class Layer extends Duplex {
     this._out.write(scratchEpilogue, null, () => {
       this._out.on('finish', () => {
         this.emit('readable');
-        //why is this not being set?
-        this._readableState.emittedReadable = true;
+        this._emittedReadable = true;
         cb();
       });
       this._out.end();
@@ -296,7 +295,7 @@ class Layer extends Duplex {
                  read then _bbox will encompass all of them
   */
   _read() {
-    if (!this._readableState.emittedReadable && !this._isPushing) {
+    if (!this._emittedReadable && !this._isPushing) {
       this.once('readable', this._startPushing.bind(this));
     } else if (!this._isPushing) {
       this._startPushing();

--- a/lib/decoders/merger.js
+++ b/lib/decoders/merger.js
@@ -8,8 +8,6 @@
  * Each layer opens a write stream on creation in a temporary location
  * and writes each feature to disk so things are not buffered
  * in memory.
- * TODO: should probably batch stuff, but this probably won't
- * be the bottleneck here.
  */
 
 import _ from 'underscore';
@@ -25,38 +23,41 @@ import {
 from 'stream';
 import Disk from './disk';
 import logger from '../util/logger';
-
+import async from 'async';
 
 const DEFAULT_CRS = "urn:ogc:def:crs:OGC:1.3:CRS84";
 
-function getOrCreateLayer(layers, soqlRow, disk, spec) {
-  var columns = soqlRow.columns;
-  var layer = layers.find((layer) => layer.belongsIn(columns));
-  if (!layer) {
-    layer = new Layer(columns.map((soqlValue) => {
-      let t = types[soqlValue.ctype];
-      if(!t) {
-        logger.warn(`No SoQLType found for ${soqlValue.ctype}, falling back to SoQLText`);
-        t = types.string;
-      }
-      return new t(soqlValue.rawName);
-    }), layers.length, disk, spec);
-    layers.push(layer);
-  }
-  return [layers, layer];
-}
 
 class Merger extends Transform {
   constructor(disk, specs, throwaway) {
     super({
       objectMode: true
     });
-    if(!disk) throw new Error("Merger needs a disk");
+    if (!disk) throw new Error("Merger needs a disk");
     this._specs = specs || [];
     this._throwaway = throwaway;
     this._disk = disk;
     this._layers = [];
     this._defaultCrs = DEFAULT_CRS;
+
+    this.once('finish', this._onFinish);
+  }
+
+  _getOrCreateLayer(soqlRow, disk, spec) {
+    var columns = soqlRow.columns;
+    var layer = this._layers.find((layer) => layer.belongsIn(columns));
+    if (!layer) {
+      layer = new Layer(columns.map((soqlValue) => {
+        let t = types[soqlValue.ctype];
+        if (!t) {
+          logger.warn(`No SoQLType found for ${soqlValue.ctype}, falling back to SoQLText`);
+          t = types.string;
+        }
+        return new t(soqlValue.rawName);
+      }), this._layers.length, disk, spec);
+      this._layers.push(layer);
+    }
+    return layer;
   }
 
   _transform(chunk, encoding, done) {
@@ -66,27 +67,23 @@ class Merger extends Transform {
     }
 
     var spec = this._specs[this._layers.length];
-    var [newLayers, layer] = getOrCreateLayer(this._layers, chunk, this._disk, spec);
-    this._layers = newLayers;
-
+    var layer = this._getOrCreateLayer(chunk, this._disk, spec);
     layer.write(chunk.crs, chunk.columns, this._throwaway, done);
   }
 
-  end() {
+  _onFinish() {
     this._layers.forEach((layer) => {
       layer.defaultCrs = this._defaultCrs;
     });
-    //idk if this is a hack. sometimes you just can't tell with node...
-    var onClosed = _.after(this._layers.length, () => {
+    async.each(this._layers, (l, cb) => l.close(cb), (err) => {
+      if(err) return this.emit('error', err);
       this.emit('end', this.layers);
     });
-    this._layers.forEach((layer) => layer.close(onClosed));
   }
 
   get layers() {
     return this._layers;
   }
 }
-
 
 export default Merger;

--- a/lib/decoders/shapefile.js
+++ b/lib/decoders/shapefile.js
@@ -255,7 +255,6 @@ class Shapefile extends Duplex {
     return true;
   }
 
-  //just cuz
   _read() {
     if (!this._readableState.emittedReadable && !this._isPushing) {
       this.once('readable', this._startPushing.bind(this));

--- a/lib/router.js
+++ b/lib/router.js
@@ -4,6 +4,7 @@
 import version from './services/version';
 import Spatial from './services/spatial';
 import Summary from './services/summary';
+import Metrics from './util/metrics';
 import logger from './util/logger';
 
 function js(req, res, next) {
@@ -20,10 +21,13 @@ function router(config, app, zookeeper) {
   var spatial = new Spatial(zookeeper);
   var summary = new Summary(config);
 
-  app.get('/version', app.logger.request(), js, version.get);
   app.post('/summary', app.logger.request(), js, summary.post.bind(summary));
   app.post('/spatial', app.logger.request(), js, spatial.create.bind(spatial));
   app.put('/spatial/:fourfours?', app.logger.request(), js, spatial.replace.bind(spatial));
+
+  //meta
+  app.get('/version', app.logger.request(), js, version.get);
+  app.get('/heapdump', app.logger.request(), Metrics.heapdump);
 }
 
 export default router;

--- a/lib/services/spatial.js
+++ b/lib/services/spatial.js
@@ -57,6 +57,7 @@ class SpatialService {
     async.mapLimit(layers, MAX_PARALLEL, core.create.bind(core), (err, datasetResponses) => {
       //failed to get upstream from zk or create request failed
       if (err) return res.status(err.statusCode || 500).send(err.body || err.toString());
+      req.log.info(`Successfully created ${layers.length} layers`);
       _.zip(layers, datasetResponses)
         .forEach(([layer, response]) => layer.uid = response.body.id);
       return this._createColumns(req, res, core, layers);
@@ -142,6 +143,7 @@ class SpatialService {
           res.status(err.statusCode || 500).send(err.body || err.toString());
         });
       }
+      req.log.info(`Successfully created ${colResponses.length} columns`);
       return this._upsertLayers(req, res, core, layers);
     });
   }
@@ -177,6 +179,7 @@ class SpatialService {
     //requests, as well as the corresponding layer. Then we need to pipe the
     //layer's scratch file to the open request
     return async.map(layers, core.upsert.bind(core), (err, upsert) => {
+      req.log.info(`Created upsert requests`);
       if (err) return fail(503, {
         message: err.toString()
       });
@@ -186,7 +189,8 @@ class SpatialService {
 
         req.log.info(`Starting upsert to ${layer.uid}`);
         var upsertRequest = upsertBuilder();
-        layer.pipe(upsertRequest)
+        layer
+          .pipe(upsertRequest)
           .on('response', (upsertResponse) => {
             req.log.info(`Got upsert response ${upsertResponse.statusCode}`);
             //bb hack to match the rest of the flow
@@ -218,7 +222,7 @@ class SpatialService {
           });
 
       }, (err, upsertResponses) => {
-        if(err) {
+        if (err) {
           req.log.error(`Upsert failed for layer ${err.layer.name} ${err.layer.uid} with ${JSON.stringify(err.reason)} in ${err.layer.scratchName}`);
           return fail(err.statusCode, err.reason);
         }
@@ -301,6 +305,7 @@ class SpatialService {
   create(req, res) {
     req.log.info("Starting create of the dataset");
     this._readShapeBlob(req, res, (core, layers) => {
+      req.log.info("Done reading shape blob, creating layers");
       return this._createLayers(req, res, core, layers);
     });
   }
@@ -308,6 +313,7 @@ class SpatialService {
   replace(req, res) {
     req.log.info("Starting replace of the dataset");
     this._readShapeBlob(req, res, (core, layers) => {
+      req.log.info("Done reading shape blob, replacing layers");
       return this._replaceLayers(req, res, core, layers);
     });
   }

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -1,6 +1,6 @@
 import logger from './logger';
 import heapdump from 'heapdump';
-
+import fs from 'fs';
 
 
 class Metrics {
@@ -8,16 +8,29 @@ class Metrics {
     setInterval(this._sampleMemory.bind(this), 1000);
   }
 
+  static heapdump(req, res) {
+    req.log.info('Making a heapdump');
+    heapdump.writeSnapshot((err, filename) => {
+      if (err) return res.status(500).send(err.toString());
+      req.log.info(`Wrote heapdump to ${filename}`);
+      fs.createReadStream(filename)
+        .pipe(res
+          .status(200)
+          .set('content-type', 'application/octet-stream')
+          .set('content-disposition', `inline; filename="${filename}"`))
+        .on('end', () => fs.unlink(filename));
+    });
+  }
+
   _sampleMemory() {
 
     var sample = process.memoryUsage();
 
-    if(this._last) {
+    if (this._last) {
       sample.rssGrowth = sample.rss / this._last.rss;
       logger.info(sample, "metrics");
-      if(sample.rssGrowth > 1.8) {
-        logger.warn("Making heapdump!");
-        heapdump.writeSnapshot();
+      if (sample.rssGrowth > 1.8) {
+        logger.warn("RSS Growth is very high!");
       }
     }
 

--- a/test/unit/merger.js
+++ b/test/unit/merger.js
@@ -15,7 +15,7 @@ import {
   fixture
 }
 from '../fixture';
-
+import through from 'through';
 import GeoJSON from '../../lib/decoders/geojson';
 import Merger from '../../lib/decoders/merger';
 import Disk from '../../lib/decoders/disk';
@@ -40,9 +40,18 @@ function makeMerger() {
   return [new Merger(new Disk(res), []), res];
 }
 
+function jsbuf() {
+  var s = '';
+  return through(function write(data) {
+    s += data.toString('utf-8');
+  }, function end() {
+    this.emit('end', JSON.parse(s));
+  });
+}
+
+
 
 describe('merging feature streams to layers', function() {
-
 
   it('will handle homogenous points, default crs', function(onDone) {
     var [merger, response] = makeMerger();
@@ -63,32 +72,32 @@ describe('merging feature streams to layers', function() {
           ['a_bool', 'boolean']
         ]);
 
-
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          expect(f0).to.eql([
-            new SoQLPoint('the_geom', {
-              coordinates: [102, 0.5]
-            }),
-            new SoQLText('a_string', 'first value'),
-            new SoQLNumber('a_num', 2),
-            new SoQLNumber('a_float', 2.2),
-            new SoQLBoolean('a_bool', false),
-          ]);
-
-          expect(f1).to.eql([
-            new SoQLPoint('the_geom', {
-              coordinates: [103, 1.5]
-            }),
-            new SoQLText('a_string', 'second value'),
-            new SoQLNumber('a_num', 2),
-            new SoQLNumber('a_float', 2.2),
-            new SoQLBoolean('a_bool', true),
-          ]);
+        layer.pipe(jsbuf()).on('end', function(jsRow) {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "Point",
+              "coordinates": [
+                102,
+                0.5
+              ]
+            },
+            "a_string": "first value",
+            "a_num": 2,
+            "a_float": 2.2,
+            "a_bool": false
+          }, {
+            "the_geom": {
+              "type": "Point",
+              "coordinates": [
+                103,
+                1.5
+              ]
+            },
+            "a_string": "second value",
+            "a_num": 2,
+            "a_float": 2.2,
+            "a_bool": true
+          }]);
 
           onDone();
         });
@@ -116,35 +125,26 @@ describe('merging feature streams to layers', function() {
         ]);
 
 
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var l0Geom = f0[0];
-          l0Geom.value.coordinates[0].should.be.approximately(-97.48, 0.01);
-          l0Geom.value.coordinates[1].should.be.approximately(0.000004, 0.01);
-
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-            new SoQLNumber('a_num', 2),
-            new SoQLNumber('a_float', 2.2),
-            new SoQLBoolean('a_bool', false),
-          ]);
-
-          var l1Geom = f1[0];
-          l1Geom.value.coordinates[0].should.be.approximately(10.78, 0.01);
-          l1Geom.value.coordinates[1].should.be.approximately(45.03, 0.01);
-
-          expect(f1.slice(1)).to.eql([
-            new SoQLText('a_string', 'second value'),
-            new SoQLNumber('a_num', 2),
-            new SoQLNumber('a_float', 2.2),
-            new SoQLBoolean('a_bool', true),
-          ]);
-
+        layer.pipe(jsbuf()).on('end', function(jsRow) {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "Point",
+              "coordinates": [-97.48783007891072, 0.000004509692825832316]
+            },
+            "a_string": "first value",
+            "a_num": 2,
+            "a_float": 2.2,
+            "a_bool": false
+          }, {
+            "the_geom": {
+              "type": "Point",
+              "coordinates": [10.788967390468883, 45.03596703206463]
+            },
+            "a_string": "second value",
+            "a_num": 2,
+            "a_float": 2.2,
+            "a_bool": true
+          }]);
           onDone();
         });
       });
@@ -172,34 +172,26 @@ describe('merging feature streams to layers', function() {
         ]);
 
 
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var theGeom = f0[0];
-          theGeom.value.coordinates[0].should.be.approximately(-97.48, 0.01);
-          theGeom.value.coordinates[1].should.be.approximately(0.000004, 0.01);
-
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-            new SoQLNumber('a_num', 2),
-            new SoQLNumber('a_float', 2.2),
-            new SoQLBoolean('a_bool', false),
-          ]);
-
-          expect(f1).to.eql([
-            new SoQLPoint('the_geom', {
-              coordinates: [103, 1.5]
-            }),
-            new SoQLText('a_string', 'second value'),
-            new SoQLNumber('a_num', 2),
-            new SoQLNumber('a_float', 2.2),
-            new SoQLBoolean('a_bool', true),
-          ]);
-
+        layer.pipe(jsbuf()).on('end', (jsRow) => {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "Point",
+              "coordinates": [-97.48783007891072, 0.000004509692825832316]
+            },
+            "a_string": "first value",
+            "a_num": 2,
+            "a_float": 2.2,
+            "a_bool": false
+          }, {
+            "the_geom": {
+              "type": "Point",
+              "coordinates": [103, 1.5]
+            },
+            "a_string": "second value",
+            "a_num": 2,
+            "a_float": 2.2,
+            "a_bool": true
+          }]);
           onDone();
         });
       });
@@ -224,41 +216,26 @@ describe('merging feature streams to layers', function() {
         ]);
 
 
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var [
-            [a, b],
-            [c, d]
-          ] = f0[0].value.coordinates;
-          a.should.be.approximately(-97.48, 0.01);
-          b.should.be.approximately(0, 0.01);
-          c.should.be.approximately(-97.48, 0.01);
-          d.should.be.approximately(0, 0.01);
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-          ]);
-
-          var l1Geom = f1[0];
-
-          [
-            [a, b],
-            [c, d]
-          ] = f1[0].value.coordinates;
-          expect(a).to.equal(101.0);
-          expect(b).to.equal(0.0);
-          expect(c).to.equal(101.0);
-          expect(d).to.equal(1.0);
-
-
-          expect(f1.slice(1)).to.eql([
-            new SoQLText('a_string', 'second value')
-          ]);
-
+        layer.pipe(jsbuf()).on('end', function(jsRow) {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "LineString",
+              "coordinates": [
+                [-97.48784799692679, 0],
+                [-97.48783903791886, 0.000009019385540221545]
+              ]
+            },
+            "a_string": "first value"
+          }, {
+            "the_geom": {
+              "type": "LineString",
+              "coordinates": [
+                [101, 0],
+                [101, 1]
+              ]
+            },
+            "a_string": "second value"
+          }]);
           onDone();
         });
       });
@@ -282,57 +259,50 @@ describe('merging feature streams to layers', function() {
         ]);
 
 
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var [
-            [
-              [a, b],
-              [c, d],
-              [e, f],
-              [g, h],
-              [i, j]
-            ],
-            [
-              [k, l],
-              [m, n],
-              [o, p],
-              [q, r],
-              [s, t]
-            ]
-          ] = f0[0].value.coordinates;
-
-          a.should.be.approximately(-97.48, 0.01);
-          k.should.be.approximately(-97.48, 0.01);
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-          ]);
-
-          expect(f1[0].value.coordinates).to.eql([
-            [
-              [100.0, 0.0],
-              [101.0, 0.0],
-              [101.0, 1.0],
-              [100.0, 1.0],
-              [100.0, 0.0]
-            ],
-            [
-              [100.2, 0.2],
-              [100.8, 0.2],
-              [100.8, 0.8],
-              [100.2, 0.8],
-              [100.2, 0.2]
-            ]
-          ]);
-
-          expect(f1.slice(1)).to.eql([
-            new SoQLText('a_string', 'second value')
-          ]);
-
+        layer.pipe(jsbuf()).on('end', function(jsRow) {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [-97.48784799692679, 0],
+                  [-97.4878390379188, 0],
+                  [-97.48783903791886, 0.000009019385540221545],
+                  [-97.48784799692685, 0.000009019385428778238],
+                  [-97.48784799692679, 0]
+                ],
+                [
+                  [-97.48784620512521, 0.0000018038770902133842],
+                  [-97.48784082972041, 0.000001803877103586581],
+                  [-97.48784082972045, 0.000007215508414346324],
+                  [-97.48784620512522, 0.000007215508360853537],
+                  [-97.48784620512521, 0.0000018038770902133842]
+                ]
+              ]
+            },
+            "a_string": "first value"
+          }, {
+            "the_geom": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [100, 0],
+                  [101, 0],
+                  [101, 1],
+                  [100, 1],
+                  [100, 0]
+                ],
+                [
+                  [100.2, 0.2],
+                  [100.8, 0.2],
+                  [100.8, 0.8],
+                  [100.2, 0.8],
+                  [100.2, 0.2]
+                ]
+              ]
+            },
+            "a_string": "second value"
+          }]);
           onDone();
         });
       });
@@ -356,36 +326,27 @@ describe('merging feature streams to layers', function() {
           ['a_string', 'string']
         ]);
 
+        layer.pipe(jsbuf()).on('end', (jsRow) => {
 
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var [
-            [a, b],
-            [c, d]
-          ] = f0[0].value.coordinates;
-          a.should.be.approximately(-97.48, 0.01);
-          b.should.be.approximately(0, 0.01);
-          c.should.be.approximately(-97.48, 0.01);
-          d.should.be.approximately(0, 0.01);
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-          ]);
-
-          expect([
-            [101.0, 0.0],
-            [101.0, 1.0]
-          ]).to.eql(f1[0].value.coordinates);
-
-
-          expect(f1.slice(1)).to.eql([
-            new SoQLText('a_string', 'second value')
-          ]);
-
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "MultiPoint",
+              "coordinates": [
+                [-97.48784799692679, 0],
+                [-97.48783903791886, 0.000009019385540221545]
+              ]
+            },
+            "a_string": "first value"
+          }, {
+            "the_geom": {
+              "type": "MultiPoint",
+              "coordinates": [
+                [101, 0],
+                [101, 1]
+              ]
+            },
+            "a_string": "second value"
+          }]);
           onDone();
         });
       });
@@ -410,51 +371,58 @@ describe('merging feature streams to layers', function() {
         ]);
 
 
-        var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var [
-            [
-              [a, b],
-              [c, d],
-            ],
-            [
-              [e, f],
-              [g, h]
-            ]
-          ] = f0[0].value.coordinates;
-
-          a.should.be.approximately(-97.48, 0.01);
-          b.should.be.approximately(0, 0.01);
-          c.should.be.approximately(-97.48, 0.01);
-          d.should.be.approximately(0, 0.01);
-          e.should.be.approximately(-97.48, 0.01);
-          f.should.be.approximately(0, 0.01);
-          g.should.be.approximately(-97.48, 0.01);
-          h.should.be.approximately(0, 0.01);
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-          ]);
-
-          expect(f1[0].value.coordinates).to.eql([
-            [
-              [101.0, 0.0],
-              [102.0, 1.0]
-            ],
-            [
-              [102.0, 2.0],
-              [103.0, 3.0]
-            ]
-          ]);
-
-          expect(f1.slice(1)).to.eql([
-            new SoQLText('a_string', 'second value')
-          ]);
-
+        layer.pipe(jsbuf()).on('end', function(jsRow) {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "MultiLineString",
+              "coordinates": [
+                [
+                  [-97.48784799692679,
+                    0
+                  ],
+                  [-97.48783903791886,
+                    0.000009019385540221545
+                  ]
+                ],
+                [
+                  [-97.48783007891092,
+                    0.000018038771303329256
+                  ],
+                  [-97.48782111990299,
+                    0.000027058157289322467
+                  ]
+                ]
+              ]
+            },
+            "a_string": "first value"
+          }, {
+            "the_geom": {
+              "type": "MultiLineString",
+              "coordinates": [
+                [
+                  [
+                    101,
+                    0
+                  ],
+                  [
+                    102,
+                    1
+                  ]
+                ],
+                [
+                  [
+                    102,
+                    2
+                  ],
+                  [
+                    103,
+                    3
+                  ]
+                ]
+              ]
+            },
+            "a_string": "second value"
+          }]);
           onDone();
         });
       });
@@ -480,69 +448,147 @@ describe('merging feature streams to layers', function() {
 
 
         var features = [];
-        layer.read().pipe(es.mapSync(function(row, i) {
-          features.push(row);
-        })).on('end', function() {
-          var [f0, f1] = features;
-
-          var [
-            [
-              [
-                [a, b]
+        layer.pipe(jsbuf()).on('end', function(jsRow) {
+          expect(jsRow).to.eql([{
+            "the_geom": {
+              "type": "MultiPolygon",
+              "coordinates": [
+                [
+                  [
+                    [-97.48783007891092,
+                      0.000018038771303329256
+                    ],
+                    [-97.48782111990273,
+                      0.00001803877152621498
+                    ],
+                    [-97.48782111990299,
+                      0.000027058157289322467
+                    ],
+                    [-97.4878300789112,
+                      0.00002705815695499387
+                    ],
+                    [-97.48783007891092,
+                      0.000018038771303329256
+                    ]
+                  ]
+                ],
+                [
+                  [
+                    [-97.48784799692679,
+                      0
+                    ],
+                    [-97.4878390379188,
+                      0
+                    ],
+                    [-97.48783903791886,
+                      0.000009019385540221545
+                    ],
+                    [-97.48784799692685,
+                      0.000009019385428778238
+                    ],
+                    [-97.48784799692679,
+                      0
+                    ]
+                  ],
+                  [
+                    [-97.48784620512521,
+                      0.0000018038770902133842
+                    ],
+                    [-97.48784082972041,
+                      0.000001803877103586581
+                    ],
+                    [-97.48784082972045,
+                      0.000007215508414346324
+                    ],
+                    [-97.48784620512522,
+                      0.000007215508360853537
+                    ],
+                    [-97.48784620512521,
+                      0.0000018038770902133842
+                    ]
+                  ]
+                ]
               ]
-            ],
-            [
-              [
-                [c, d],
-              ],
-              [
-                [e, f],
+            },
+            "a_string": "first value"
+          }, {
+            "the_geom": {
+              "type": "MultiPolygon",
+              "coordinates": [
+                [
+                  [
+                    [
+                      103,
+                      2
+                    ],
+                    [
+                      102,
+                      2
+                    ],
+                    [
+                      103,
+                      3
+                    ],
+                    [
+                      102,
+                      3
+                    ],
+                    [
+                      103,
+                      2
+                    ]
+                  ]
+                ],
+                [
+                  [
+                    [
+                      100,
+                      0
+                    ],
+                    [
+                      101,
+                      0
+                    ],
+                    [
+                      101,
+                      1
+                    ],
+                    [
+                      100,
+                      1
+                    ],
+                    [
+                      100,
+                      0
+                    ]
+                  ],
+                  [
+                    [
+                      100.2,
+                      0.2
+                    ],
+                    [
+                      100.8,
+                      0.2
+                    ],
+                    [
+                      100.8,
+                      0.8
+                    ],
+                    [
+                      100.2,
+                      0.8
+                    ],
+                    [
+                      100.2,
+                      0.2
+                    ]
+                  ]
+                ]
               ]
-            ]
-          ] = f0[0].value.coordinates;
-
-          a.should.be.approximately(-97.48, 0.01);
-          b.should.be.approximately(0, 0.01);
-          c.should.be.approximately(-97.48, 0.01);
-          d.should.be.approximately(0, 0.01);
-          e.should.be.approximately(-97.48, 0.01);
-          f.should.be.approximately(0, 0.01);
-
-          expect(f0.slice(1)).to.eql([
-            new SoQLText('a_string', 'first value'),
-          ]);
-
-          expect(f1[0].value.coordinates).to.eql([
-            [
-              [
-                [103.0, 2.0],
-                [102.0, 2.0],
-                [103.0, 3.0],
-                [102.0, 3.0],
-                [103.0, 2.0]
-              ]
-            ],
-            [
-              [
-                [100.0, 0.0],
-                [101.0, 0.0],
-                [101.0, 1.0],
-                [100.0, 1.0],
-                [100.0, 0.0]
-              ],
-              [
-                [100.2, 0.2],
-                [100.8, 0.2],
-                [100.8, 0.8],
-                [100.2, 0.8],
-                [100.2, 0.2]
-              ]
-            ]
-          ]);
-
-          expect(f1.slice(1)).to.eql([
-            new SoQLText('a_string', 'second value')
-          ]);
+            },
+            "a_string": "second value"
+          }]);
 
           onDone();
         });


### PR DESCRIPTION
* Add heapdump endpoint
* Remove rss growth heapdump trigger thing
* Remove mem buffering in layer disk writes, it was dumb
* Remove weird read() and pipe() methods in layer
  which were written before i understood how node streams
  were supposed to work. Now layer is a (sort of) regular duplex
  stream.
* Change layer tests in unit/merger.js to match the lack of a weird
  read() method that gives back a new object mode stream
* More logging