### PR TITLE
Get rid of through2 lib usage

### DIFF
--- a/es6-lib/decoders/kml.js
+++ b/es6-lib/decoders/kml.js
@@ -20,7 +20,6 @@ import {
 }
 from './transform';
 import config from '../config';
-import through from 'through';
 
 
 //kml has no facilities for name the geometry

--- a/es6-lib/decoders/kmz.js
+++ b/es6-lib/decoders/kmz.js
@@ -1,6 +1,5 @@
 import yauzl from 'yauzl';
 import KML from './kml';
-import through from 'through';
 import uuid from 'uuid';
 import fs from 'fs';
 import path from 'path';

--- a/es6-lib/decoders/layer.js
+++ b/es6-lib/decoders/layer.js
@@ -22,7 +22,6 @@ import {
   types
 }
 from '../soql/mapper';
-import split2 from 'split2';
 import logger from '../util/logger';
 import conf from '../config';
 import LDJson from './ldjson';

--- a/es6-lib/decoders/ldjson.js
+++ b/es6-lib/decoders/ldjson.js
@@ -1,0 +1,57 @@
+import _ from 'underscore';
+import {
+  Transform
+}
+from 'stream';
+import config from '../config';
+
+class LDJson extends Transform {
+
+  constructor(columns) {
+    super({
+      writableObjectMode: false,
+      readableObjectMode: true,
+      highWaterMark: config().rowBufferSize
+    });
+    this._buf = '';
+  }
+
+  _push(token) {
+    try {
+      this.push(JSON.parse(token));
+    } catch(e) {
+
+    }
+  }
+
+  _transform(buf, _encoding, done) {
+    //_buf = a0
+    //tokens = [a1, b0, c0]
+    var tokens = buf.toString('utf-8').split('\n');
+
+    //rest = c0
+    //tokens  = [a0, b0]
+    var rest = tokens.pop();
+
+    if(tokens.length >= 1) {
+      var token = this._buf + tokens.shift();
+      this._push(token);
+      //tokens = [b0]
+    } else {
+      rest = this._buf + rest;
+    }
+
+    tokens.forEach(this._push.bind(this));
+
+    this._buf = rest;
+
+    done();
+  }
+
+  _flush(done) {
+    this._push(this._buf);
+    done();
+  }
+}
+
+export default LDJson;

--- a/es6-lib/decoders/wgs84-reprojector.js
+++ b/es6-lib/decoders/wgs84-reprojector.js
@@ -1,0 +1,66 @@
+import _ from 'underscore';
+import {
+  Transform
+}
+from 'stream';
+import config from '../config';
+import {
+  types
+}
+from '../soql/mapper';
+import srs from 'node-srs';
+import BBox from '../util/bbox';
+
+
+const WGS84 = '+proj=longlat +ellps=WGS84 +no_defs';
+
+class WGS84Reprojector extends Transform {
+
+  constructor(columns) {
+    super({
+      objectMode: true,
+      highWaterMark: config().rowBufferSize
+    });
+    this._columns = columns;
+    this._projectTo = srs.parse(WGS84);
+    this._bbox = new BBox();
+  }
+
+  get projection() {
+    return this._projectTo;
+  }
+
+  get bbox() {
+    return this._bbox;
+  }
+
+  _expandBbox(geom) {
+    //yes a map is silly here because this is a side effect on the layer
+    //but it keeps things simple
+    geom.mapCoordinates((coord) => {
+      this.bbox.expand(coord);
+    });
+  }
+
+  _transform([projection, row], _encoding, done) {
+    var reprojected = _.zip(this._columns, row).map(([column, value]) => {
+      var soql = new types[column.ctype](column.rawName, value);
+      if (soql.isGeometry) {
+        let geom = soql.reproject(projection, this.projection);
+        this._expandBbox(geom);
+        return geom;
+      }
+      return soql;
+    });
+
+    var asSoda = reprojected.reduce((acc, col) => {
+      acc[col.name] = col.value;
+      return acc;
+    }, {});
+
+    var asString = JSON.stringify(asSoda);
+    return done(false, asString);
+  }
+}
+
+export default WGS84Reprojector;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "change-case": "latest",
     "event-stream": "latest",
     "express": "latest",
-    "ldjson-stream": "latest",
     "node-expat": "latest",
     "node-inspector": "~0.12.3",
     "node-zookeeper-client": "latest",


### PR DESCRIPTION
* through2 hardcodes the highwatermark
  which is problematic for complex shapes
* ldjson stream uses through2, so drop that
  as well
* re-implement ldjson stream in ldjson.js
* re-implement through2 reprojection that lived
  in layer.js in wgs84-reprojector