### PR TITLE
Refs EN-1592

### DIFF
--- a/es6-lib/decoders/layer.js
+++ b/es6-lib/decoders/layer.js
@@ -269,6 +269,9 @@ class Layer extends Duplex {
         if(!self.push(sep + rowString + ep)) {
           this.pause();
 
+          //our reader has gone away, this kills the stream.
+          //so end the stream with a null and flush anything
+          //that's buffered into oblivion
           if (!self._readableState.pipes) {
             self.push(null);
             return self.pipe(new DevNull());

--- a/es6-lib/decoders/layer.js
+++ b/es6-lib/decoders/layer.js
@@ -25,6 +25,7 @@ from '../soql/mapper';
 import logger from '../util/logger';
 import LDJson from './ldjson';
 import WGS84Reprojector from './wgs84-reprojector';
+import DevNull from '../util/devnull';
 
 const scratchPrologue = "";
 const scratchSeparator = "\n";
@@ -267,6 +268,12 @@ class Layer extends Duplex {
 
         if(!self.push(sep + rowString + ep)) {
           this.pause();
+
+          if (!self._readableState.pipes) {
+            self.push(null);
+            return self.pipe(new DevNull());
+          }
+
           self._readableState.pipes.once('drain', this.resume.bind(this));
         }
       }, function end() {

--- a/es6-lib/decoders/shapefile.js
+++ b/es6-lib/decoders/shapefile.js
@@ -32,6 +32,7 @@ from 'events';
 import async from 'async';
 import logger from '../util/logger';
 import config from '../config';
+import DevNull from '../util/devnull';
 
 const DEFAULT_PROJECTION = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
 
@@ -119,6 +120,14 @@ class Shapefile extends Duplex {
     }
 
     if (!this.push(geoJsToSoQL(record, projection))) {
+          //our reader has gone away, this kills the stream.
+          //so end the stream with a null and flush anything
+          //that's buffered into oblivion
+          if (!this._readableState.pipes) {
+            this.push(null);
+            return this.pipe(new DevNull());
+          }
+
       this._readableState.pipes.once('drain', readNext);
     } else {
       readNext();

--- a/es6-test/smoke/flow-control.js
+++ b/es6-test/smoke/flow-control.js
@@ -125,7 +125,7 @@ describe('flow control', () => {
       });
   });
 
-  it('will not stop reading kmz stream consumer is unpiped', function(onDone) {
+  it('will not stop reading when kmz stream consumer is unpiped', function(onDone) {
     //for jankins
     this.timeout(10000);
 


### PR DESCRIPTION
* KMZ, Shapefile, and Layer all listen to downstream streams
  to pause/unpause themselves. They didn't handle the case
  where the downstream stream disappears mid-run. Now they
  handle that case. They do not pause and buffer data, they
  simply EOF
* Added tests in smoke/flow-control for these cases