### PR TITLE
Fix semantics of lines before upsert

### DIFF
--- a/es6-lib/soql/line.js
+++ b/es6-lib/soql/line.js
@@ -10,6 +10,21 @@ class SoQLLine extends SoQLGeom {
     return 'linestring';
   }
 
+  //[[x,y]] will become [[x,y],[x,y]] because the java
+  //lib used in soda-fountain throws an exception if a line
+  //is just a point
+  static linify(line) {
+    if (line.length < 2) {
+      line.push(line[0]);
+    }
+    return line;
+  }
+
+  fixSemantics() {
+    this._value = SoQLLine.linify(this._value);
+    return this;
+  }
+
   mapCoordinates(fn) {
     return this._value.map(fn);
   }

--- a/es6-lib/soql/multiline.js
+++ b/es6-lib/soql/multiline.js
@@ -1,4 +1,5 @@
 import SoQLGeom from './geom';
+import SoQLLine from './line';
 
 class SoQLMultiLine extends SoQLGeom {
   get _type() {
@@ -7,6 +8,11 @@ class SoQLMultiLine extends SoQLGeom {
 
   static ctype() {
     return 'multilinestring';
+  }
+
+  fixSemantics() {
+    this._value = this._value.map(SoQLLine.linify);
+    return this;
   }
 
   mapCoordinates(fn) {

--- a/es6-test/fixtures/non-line-lines.json
+++ b/es6-test/fixtures/non-line-lines.json
@@ -1,0 +1,22 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[100.0, 0.0]]
+       },
+
+      "type": "Feature",
+      "properties": {
+        "a_string": "first value"
+      },
+      "crs": {
+        "type": "name",
+        "properties": {
+          "name": "urn:ogc:def:crs:EPSG::26915"
+        }
+      }
+    }
+  ]
+}

--- a/es6-test/fixtures/non-line-multiline.json
+++ b/es6-test/fixtures/non-line-multiline.json
@@ -1,0 +1,22 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "MultiLineString",
+        "coordinates": [[[100.0, 0.0]]]
+       },
+
+      "type": "Feature",
+      "properties": {
+        "a_string": "first value"
+      },
+      "crs": {
+        "type": "name",
+        "properties": {
+          "name": "urn:ogc:def:crs:EPSG::26915"
+        }
+      }
+    }
+  ]
+}

--- a/es6-test/unit/geometry-transforms.js
+++ b/es6-test/unit/geometry-transforms.js
@@ -10,6 +10,32 @@ var expect = chai.expect;
 
 describe('geometry transforms', function() {
 
+  it('can linify a line which is just a point', function(onDone) {
+    fixture('non-line-lines.json')
+      .pipe(new GeoJSON())
+      .pipe(es.mapSync(function(row) {
+        var line = row.columns[0].fixSemantics();
+        expect(line.value.coordinates).to.eql([
+          [100.0, 0.0],
+          [100.0, 0.0]
+        ])
+      }))
+      .on('end', onDone);
+  });
+
+  it('can linify a multiline which is just a point', function(onDone) {
+    fixture('non-line-multiline.json')
+      .pipe(new GeoJSON())
+      .pipe(es.mapSync(function(row) {
+        var line = row.columns[0].fixSemantics();
+        expect(line.value.coordinates).to.eql([[
+          [100.0, 0.0],
+          [100.0, 0.0]
+        ]])
+      }))
+      .on('end', onDone);
+  });
+
   it('can close an unclosed polygon', function(onDone) {
     var geoms = [];
     fixture('unclosed_polygons.json')


### PR DESCRIPTION
* Soda-fountain rejects lines that only have a single point.
  Some datasets in kml and geojson format have single points,
  so this fix puts them in a form that the library used by
  soda-fountain will accept
* Added tests

Refs EN-2061