### PR TITLE
Fix massive bug

### DIFF
--- a/es6-lib/services/spatial.js
+++ b/es6-lib/services/spatial.js
@@ -126,11 +126,7 @@ class SpatialService {
     };
 
     async.seq(createOrReplace, flatColumns, deleteColumns)(layers, (err, newLayers) => {
-      if (err) {
-        return this._destroyLayers(layers, core, () => {
-          return res.status(err.statusCode || 500).send(err.body || err.toString());
-        });
-      }
+      if (err) return res.status(err.statusCode).send(err.toString());
       return this._createColumns(req, res, core, newLayers);
     });
   }

--- a/es6-test/unit/spatial.js
+++ b/es6-test/unit/spatial.js
@@ -516,7 +516,7 @@ describe('spatial service', function() {
   });
 
 
-  it('will delete any created layers when an error is encountered getting column info', function(onDone) {
+  it('will not delete any replacement layers when an error is encountered getting column info', function(onDone) {
     mockCore.failGetColumns = 503;
     var names = {
       names: ['A new layer name']
@@ -533,15 +533,15 @@ describe('spatial service', function() {
         }
       })), (resp, buffered) => {
         mockCore.failGetColumns = false;
-        var del0 = _.last(mockCore.history);
-        expect(del0.method).to.equal('DELETE')
-        expect(del0.url).to.equal('/views/qs32-qpt8')
+        var colInfo = _.last(mockCore.history);
+        expect(colInfo.method).to.equal('GET');
+        expect(colInfo.url).to.equal('/views/qs32-qpt8/columns');
         onDone();
       });
   });
 
 
-  it('will delete any created layers when an error is encountered in delete columns', function(onDone) {
+  it('will not delete any created layers when an error is encountered in delete columns', function(onDone) {
     mockCore.failDeleteColumns = 503;
     var names = {
       names: ['A new layer name']
@@ -558,9 +558,9 @@ describe('spatial service', function() {
         }
       })), (resp, buffered) => {
         mockCore.failColumns = false;
-        var del0 = _.last(mockCore.history);
-        expect(del0.method).to.equal('DELETE')
-        expect(del0.url).to.equal('/views/qs32-qpt8')
+        var deleteColumn = _.last(mockCore.history);
+        expect(deleteColumn.method).to.equal('DELETE');
+        expect(deleteColumn.url).to.equal('/views/qs32-qpt8/columns/3416');
         onDone();
       });
   });


### PR DESCRIPTION
* When a replace request was made, if an error was encountered,
  it would clean up the layers rather than leaving them. We only
  want this logic on the new dataset path because replacement
  layers are working copies not new datasets.
* Updated tests

Refs EN-2456