### PR TITLE
Found the actual problem

### DIFF
--- a/es6-test/smoke/kml-http.js
+++ b/es6-test/smoke/kml-http.js
@@ -130,4 +130,23 @@ describe('kml ingress', () => {
         onDone();
       });
   });
+
+  it('should be able to do la bikelanes KML upsert', function(onDone) {
+    //long timeout for jankins
+    this.timeout(25000);
+    bufferJs(fixture('smoke/la_bikelanes.kml')
+      .pipe(request.post({
+        url: url + '/spatial',
+        headers: {
+          'Authorization': 'test-auth',
+          'X-App-Token': 'app-token',
+          'X-Socrata-Host': 'localhost:6668',
+          'Content-Type': 'application/vnd.google-earth.kml+xml'
+        }
+      })), (res, buffered) => {
+        expect(res.statusCode).to.equal(200);
+        expect(buffered.layers.length).to.equal(4);
+        onDone();
+      });
+  });
 });


### PR DESCRIPTION
* Layer class method belongsIn was returning true when `this`
  was a subset of the row comparing against, so it would erroneously
  merge rows into layers that they didn't belong. This resulted
  in incorrect files that were spilled to disk.
* The strange thing is that instead of a 400 Bad request from
  the upstream server, it would just hang and give a socket
  timeout.

Refs EN-1835