### PR TITLE
Fix the regression tests

### DIFF
--- a/es6-lib/consumer.js
+++ b/es6-lib/consumer.js
@@ -1,7 +1,6 @@
 import Stomp from 'stomp-client';
 import Spatial from './services/spatial';
 import logger from './util/logger';
-import ISS from './upstream/iss';
 import async from 'async';
 import _ from 'underscore';
 
@@ -30,8 +29,7 @@ function consumer(config, zookeeper, metrics, onStarted) {
       );
       amq.connect((sessionId) => {
         logger.info(`Connected to amq with ${sessionId}`);
-        const spatialConsumer = new Spatial(zookeeper, amq, new ISS(amq));
-
+        const spatialConsumer = new Spatial(zookeeper, amq);
         cb(null, spatialConsumer);
       });
 

--- a/es6-lib/services/spatial.js
+++ b/es6-lib/services/spatial.js
@@ -24,6 +24,7 @@ from '../soql/mapper';
 import Layer from '../decoders/layer';
 import config from '../config';
 import logger from '../util/logger';
+import ISS from '../upstream/iss';
 
 //TODO: resource scope?
 import EventEmitter from 'events';
@@ -37,14 +38,12 @@ function totalLayerRows(layers) {
 }
 
 class SpatialService {
-  constructor(zookeeper, amq, iss) {
+  constructor(zookeeper, amq) {
     if (!zookeeper) throw new Error("SpatialService needs zookeeper!");
     if (!amq) throw new Error("SpatialService needs amq!");
-    if (!iss) throw new Error("SpatialService needs iss!");
 
     this._inFlight = 0;
     this._zk = zookeeper;
-    this._iss = iss;
     this._onComplete = () => {
       logger.info('No jobs in progress...');
     };
@@ -57,7 +56,8 @@ class SpatialService {
     const saneMessage = parseAMQMessage(message);
     logger.info(`Got a message ${JSON.stringify(saneMessage)}`);
 
-    const activity = this._iss.activity(saneMessage);
+    const iss = new ISS(this._amq);
+    const activity = iss.activity(saneMessage);
     //Send iss a start message
     activity.onStart();
 

--- a/es6-test/unit/spatial.js
+++ b/es6-test/unit/spatial.js
@@ -32,8 +32,6 @@ describe('spatial service', function() {
 
   var mockCore;
   const mockAmq = new AmqMock();
-  const iss = new ISS(mockAmq);
-  iss.setMaxListeners(100);
 
   //start on ISS mocking, hook into events from ISS
   //for testing the actual imports
@@ -44,7 +42,7 @@ describe('spatial service', function() {
   before(function(onDone) {
     mockZk = new MockZKClient(corePort);
     mockZk.on('connected', () => {
-      service = new SpatialService(mockZk, mockAmq, iss);
+      service = new SpatialService(mockZk, mockAmq);
       onDone();
     });
     mockZk.connect();


### PR DESCRIPTION
* parallel cheetah tests uncovered a bug
  where files were being cleaned up before they
  should have because everyone was using the same ISS
  instance, which emitted an end event for ISS rather
  than the activity, causing all files to get collected.
* solution: everyone gets their own ISS