### PR TITLE
EN-6393: Fix column name laundering

### DIFF
--- a/es6-lib/decoders/geojson.js
+++ b/es6-lib/decoders/geojson.js
@@ -7,7 +7,7 @@
 import es from 'event-stream';
 import _ from 'underscore';
 import {
-  toRow, geomToSoQL, propToSoQL, geoJsToSoQL
+  geoJsToSoQL
 }
 from './transform';
 import {

--- a/es6-lib/decoders/kml.js
+++ b/es6-lib/decoders/kml.js
@@ -16,7 +16,7 @@ import {
 }
 from '../soql/mapper';
 import {
-  toRow, geomToSoQL, propToSoQL
+  toRow, geomToSoQL
 }
 from './transform';
 import config from '../config';

--- a/es6-lib/decoders/layer.js
+++ b/es6-lib/decoders/layer.js
@@ -38,6 +38,50 @@ const jsonEpilogue = "]";
 
 
 
+/**
+ * This renames columns that have the different names in the
+ * input format (foo_bar, FOO_BAR) that are then the same
+ * once we launder them in order to put them in socrata.
+ * we need to launder the column names to not have upper
+ * case letters, among other things. So that means the
+ * laundering process can cause two columns to collide,
+ * which is not allowed.
+ *
+ * This function ensures that the columns as represented
+ * in the layer never have name collisions.
+ *
+ * If we have
+ * [
+ *   SoQLText("foo_bar": "hi"),
+ *   SoQLText("FOO_BAR": "hello"),
+ *   SoQLText("FOO_bar": "sup")
+ * ]
+ *
+ * then this function would turn that into
+ * [
+ *   SoQLText("foo_bar": "hi"),
+ *   SoQLText("foo_bar_1": "hello"),
+ *   SoQLText("foo_bar_2": "sup")
+ * ]
+ */
+function renameColumns(columns) {
+  var prohibitedNames = {};
+  return columns.map(c => {
+    var index = 0;
+    var name = c.name;
+    while (prohibitedNames[name]) {
+      var orig = _.first(name.split(/_\d+$/));
+      if (orig) {
+        name = orig;
+        index++;
+      }
+      name = `${name}_${index}`;
+    }
+    prohibitedNames[name] = true;
+    return c.setName(name);
+  });
+}
+
 class Layer extends Duplex {
   static get EMPTY() {
     return '__empty__';
@@ -48,11 +92,11 @@ class Layer extends Duplex {
     super();
     this._position = position;
 
-    this.columns = columns;
+    this.columns = renameColumns(columns);
     this._count = 0;
     this._crsMap = {};
     this._crsCache = {};
-    this._wgs84Reprojector = new WGS84Reprojector(columns);
+    this._wgs84Reprojector = new WGS84Reprojector();
     this._spec = spec || {};
 
     if (disk) {
@@ -181,7 +225,7 @@ class Layer extends Duplex {
 
     if (toAdd.length === 0) return;
 
-    this.columns = this.columns.map((col) => {
+    this.columns = renameColumns(this.columns.map((col) => {
       var valCol = _.find(toAdd, (newCol) => newCol.rawName === col.rawName);
       var newCol;
       if (valCol) {
@@ -189,7 +233,7 @@ class Layer extends Duplex {
         logger.debug(`Replacing old undefined column ${valCol.rawName} with new ${valCol.constructor.name} column`);
       }
       return newCol || col;
-    });
+    }));
   }
 
   /**
@@ -266,8 +310,14 @@ class Layer extends Duplex {
     this.push(jsonPrologue);
     fs.createReadStream(this._outName)
       .pipe(new LDJson())
-      .pipe(es.mapSync((row) => {
-        var thing = [this._getProjectionFor(prjIndex), row];
+      .pipe(es.mapSync((textRow) => {
+        const soqlRow = renameColumns(
+          _.zip(this.columns, textRow).map(([column, value]) => {
+            return new types[column.ctype](column.rawName, value);
+          })
+        );
+
+        var thing = [this._getProjectionFor(prjIndex), soqlRow];
         prjIndex++;
         return thing;
       }))
@@ -277,7 +327,6 @@ class Layer extends Duplex {
         var ep = '';
         writeIndex++;
         if (writeIndex === self._count) ep = jsonEpilogue;
-
         if (!self.push(sep + rowString + ep)) {
           this.pause();
           //our reader has gone away, this kills the stream.

--- a/es6-lib/decoders/transform.js
+++ b/es6-lib/decoders/transform.js
@@ -71,12 +71,11 @@ function geomToSoQL(geom) {
     logger.warn(`Invalid geom property, ${typeof value} ${value}`);
     return false;
   }
-  return new t(GEOM_NAME, geom);
+  return new t(GEOM_NAME, geom, {});
 }
 
 function toRow(geometry, geomToSoQL, properties, propToSoQL, crs) {
   var soqlGeom = geomToSoQL(geometry);
-
   var soqlProps = [];
   if (properties) {
     for (var k in properties) {

--- a/es6-lib/decoders/wgs84-reprojector.js
+++ b/es6-lib/decoders/wgs84-reprojector.js
@@ -16,12 +16,11 @@ const WGS84 = '+proj=longlat +ellps=WGS84 +no_defs';
 
 class WGS84Reprojector extends Transform {
 
-  constructor(columns) {
+  constructor() {
     super({
       objectMode: true,
       highWaterMark: config().rowBufferSize
     });
-    this._columns = columns;
     this._projectTo = srs.parse(WGS84);
     this._bbox = new BBox();
   }
@@ -44,10 +43,8 @@ class WGS84Reprojector extends Transform {
 
   _transform([projection, row], _encoding, done) {
     try {
-      var reprojected = _.zip(this._columns, row).map(([column, value]) => {
-        var soql = new types[column.ctype](column.rawName, value);
+      var reprojected = row.map((soql) => {
         if (soql.isGeometry) {
-
           if (!soql.isCorrectArity()) {
             logger.error(`Found invalid arity with geom ${soql}`);
             throw new Error({

--- a/es6-lib/soql/date.js
+++ b/es6-lib/soql/date.js
@@ -2,8 +2,8 @@ import _ from 'underscore';
 import SoQL from './soql';
 
 class SoQLDate extends SoQL {
-  constructor(name, value) {
-    super(name, value);
+  constructor(name, value, prohibitedNames) {
+    super(name, value, prohibitedNames);
     if(_.isDate(value)) {
       this.value = value.toISOString();
     }

--- a/es6-lib/soql/soql.js
+++ b/es6-lib/soql/soql.js
@@ -2,43 +2,33 @@ import _ from 'underscore';
 import changeCase from 'change-case';
 
 
+function launderName(name) {
+  name = name.trim();
+  //_.isNumber(NaN) === true...so that's what i'm not using it here
+  var isNumber = !_.isNaN(parseInt(name[0]));
+
+  // Suppose we have columns in one layer
+  // called `NAME` and `name`, snakecase itself will convert
+  // these to `name` and `name`. So we need to convert them
+  // to `__name` and `name` so they don't collide.
+  // Why the double underscore?
+  // Suppose we have columns in one layer
+  // called 'ID'. Single underscore would be converted
+  // to `_id` which is reserved. So a double underscore fixes
+  // this ;_;
+  var l = name;
+  name = changeCase.snakeCase(name);
+  if (isNumber) {
+    name = '_' + name;
+  }
+  return name;
+}
+
 class SoQL {
   constructor(name, value) {
     this.rawName = name;
-    this.name = this._launderName(name);
+    this.name = launderName(name);
     this.value = value;
-  }
-
-  /**
-   * This is all the old geo importer did.
-   * TODO: this is necessary, but is this sufficient?
-   */
-  _launderName(name) {
-    name = name.trim();
-    var start = name[0];
-    //_.isNumber(NaN) === true...so that's what i'm not using
-    //it here
-    var isNumber = !_.isNaN(parseInt(start));
-    var isUpper = start.toUpperCase() === start;
-
-
-    // Suppose we have columns in one layer
-    // called `NAME` and `name`, snakecase itself will convert
-    // these to `name` and `name`. So we need to convert them
-    // to `__name` and `name` so they don't collide.
-    // Why the double underscore?
-    // Suppose we have columns in one layer
-    // called 'ID'. Single underscore would be converted
-    // to `_id` which is reserved. So a double underscore fixes
-    // this ;_;
-
-    name = changeCase.snakeCase(name);
-    if(isNumber) {
-      name = '_' + name;
-    } else if(isUpper) {
-      name = '__' + name;
-    }
-    return name;
   }
 
   /**
@@ -46,6 +36,11 @@ class SoQL {
   */
   get dataTypeName() {
     return this.constructor.name.slice(4).toLowerCase();
+  }
+
+  setName(name) {
+    this.name = launderName(name);
+    return this;
   }
 
   /**
@@ -68,4 +63,5 @@ class SoQL {
   }
 }
 
-export default SoQL;
+export
+default SoQL;

--- a/es6-lib/soql/soql.js
+++ b/es6-lib/soql/soql.js
@@ -4,18 +4,9 @@ import changeCase from 'change-case';
 
 function launderName(name) {
   name = name.trim();
-  //_.isNumber(NaN) === true...so that's what i'm not using it here
+  //_.isNumber(NaN) === true...so that's why i'm not using it here
   var isNumber = !_.isNaN(parseInt(name[0]));
 
-  // Suppose we have columns in one layer
-  // called `NAME` and `name`, snakecase itself will convert
-  // these to `name` and `name`. So we need to convert them
-  // to `__name` and `name` so they don't collide.
-  // Why the double underscore?
-  // Suppose we have columns in one layer
-  // called 'ID'. Single underscore would be converted
-  // to `_id` which is reserved. So a double underscore fixes
-  // this ;_;
   var l = name;
   name = changeCase.snakeCase(name);
   if (isNumber) {

--- a/es6-lib/soql/text.js
+++ b/es6-lib/soql/text.js
@@ -1,8 +1,8 @@
 import SoQL from './soql';
 
 class SoQLText extends SoQL {
-  constructor(name, value) {
-    super(name, value);
+  constructor(name, value, prohibitedNames) {
+    super(name, value, prohibitedNames);
     /**
      * Underlying shapefile parser gives back
      * '\u0000' for null values in text columns

--- a/es6-test/fixtures/simple_points_dup_columns.json
+++ b/es6-test/fixtures/simple_points_dup_columns.json
@@ -1,0 +1,21 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          102.0,
+          0.5
+        ]
+      },
+      "properties": {
+        "a_string": "first string",
+        "A_STRING": "second string",
+        "A_string": "third string",
+        "a_String": "fourth string"
+      }
+    }
+  ]
+}

--- a/es6-test/smoke/decoders.js
+++ b/es6-test/smoke/decoders.js
@@ -223,15 +223,15 @@ describe('decoders', () => {
     var [decoder, res] = kmzDecoder();
     var rows = [];
     var expected = ['the_geom',
-      '__objectid',
-      '__area',
-      '__perimeter',
-      '__patternc',
-      '__patternc_i',
-      '__districtc',
-      '__square_mil',
-      '__shape_leng',
-      '__shape_area'
+      'objectid',
+      'area',
+      'perimeter',
+      'patternc',
+      'patternc_i',
+      'districtc',
+      'square_mil',
+      'shape_leng',
+      'shape_area'
     ].sort();
 
     fixture('smoke/police_beats_patternc.kmz')

--- a/es6-test/smoke/merger.js
+++ b/es6-test/smoke/merger.js
@@ -70,31 +70,31 @@ describe('merger', () => {
             name: 'the_geom',
             dataTypeName: 'line'
           }, {
-            fieldName: '__facility',
+            fieldName: 'facility',
             name: 'FACILITY',
             dataTypeName: 'text'
           }, {
-            fieldName: '__type',
+            fieldName: 'type',
             name: 'TYPE',
             dataTypeName: 'text'
           }, {
-            fieldName: '__year_const',
+            fieldName: 'year_const',
             name: 'YEAR_CONST',
             dataTypeName: 'number'
           }, {
-            fieldName: '__nghbrhd',
+            fieldName: 'nghbrhd',
             name: 'NGHBRHD',
             dataTypeName: 'text'
           }, {
-            fieldName: '__nghbrhd_id',
+            fieldName: 'nghbrhd_id',
             name: 'NGHBRHD_ID',
             dataTypeName: 'text'
           }, {
-            fieldName: '__ward',
+            fieldName: 'ward',
             name: 'WARD',
             dataTypeName: 'text'
           }, {
-            fieldName: '__str_ave',
+            fieldName: 'str_ave',
             name: 'STR_AVE',
             dataTypeName: 'text'
           }]);

--- a/es6-test/unit/merger.js
+++ b/es6-test/unit/merger.js
@@ -615,4 +615,22 @@ describe('merging feature streams to layers', function() {
         onDone();
       });
   });
+
+  it('will dedupe column names that end up the same after laundering', function(onDone) {
+    var [merger, response] = makeMerger();
+    fixture('simple_points_dup_columns.json')
+      .pipe(new GeoJSON())
+      .pipe(merger)
+      .on('end', ([layer]) => {
+        layer.pipe(jsbuf()).on('end', ([row]) => {
+
+          expect(row.a_string).to.equal('first string');
+          expect(row.a_string_1).to.equal('second string');
+          expect(row.a_string_2).to.equal('third string');
+          expect(row.a_string_3).to.equal('fourth string');
+
+          onDone();
+        })
+      });
+  });
 });

--- a/es6-test/unit/shapefile.js
+++ b/es6-test/unit/shapefile.js
@@ -69,8 +69,8 @@ describe('shapefile decoder', function() {
     fixture('dates.zip')
       .pipe(decoder)
       .pipe(es.mapSync(function(feature) {
-        var [date, gpsDate] = feature.columns.filter((c) => (c.name === '__gps_date') || (c.name === '__date'));
-          //just check that the date is ISO8601 parsable
+        var [date, gpsDate] = feature.columns.filter((c) => (c.name === 'gps_date') || (c.name === 'date'));
+        //just check that the date is ISO8601 parsable
         expect(Date.parse(date.value).toString()).to.not.equal('Invalid Date');
         expect(Date.parse(gpsDate.value).toString()).to.not.equal('Invalid Date');
       })).on('end', onDone);

--- a/es6-test/unit/soql.js
+++ b/es6-test/unit/soql.js
@@ -20,13 +20,13 @@ describe('layer', function() {
     expect(t.name).to.equal('foo_bar');
 
     var t = new SoQLText('FOOBAR', 'some text')
-    expect(t.name).to.equal('__foobar');
+    expect(t.name).to.equal('foobar');
 
     var t = new SoQLText('         foobar', 'some text')
     expect(t.name).to.equal('foobar');
 
     var t = new SoQLText('FooBar', 'some text')
-    expect(t.name).to.equal('__foo_bar');
+    expect(t.name).to.equal('foo_bar');
 
   });
 

--- a/es6-test/unit/summary.js
+++ b/es6-test/unit/summary.js
@@ -209,7 +209,7 @@ describe('summary service', () => {
           name: 'the_geom',
           dataTypeName: 'line'
         }, {
-          fieldName: '__a_string',
+          fieldName: 'a_string',
           name: 'A_STRING',
           dataTypeName: 'text'
         }]);


### PR DESCRIPTION
* The previous approach was bad and i feel bad
* This is a little better
* Added a test
* Fixed the gross tests which had double-underscored columns
* Also removed some unused imports