### PR TITLE
EN-10317

### DIFF
--- a/es6-lib/errors.js
+++ b/es6-lib/errors.js
@@ -283,6 +283,11 @@ class DeleteColumnError extends UpstreamError {
     return 'Failed to delete a column of that dataset';
   }
 }
+class SetBlobError extends UpstreamError {
+  static template() {
+    return 'Failed to set the file data attribute of that dataset';
+  }
+}
 class UpdateMetadataError extends UpstreamError {
   static template() {
     return 'Failed to update the metadata on the partent dataset';
@@ -321,5 +326,6 @@ default {
   CorruptShapefileError,
   IncompleteShapefileError,
   DecodeFiletypeError,
-  ConnectionError
+  ConnectionError,
+  SetBlobError
 };

--- a/es6-lib/services/spatial.js
+++ b/es6-lib/services/spatial.js
@@ -70,7 +70,7 @@ class SpatialService {
 
 
   _createOrReplace(activity, core, layer, cb) {
-    const rollbackWorkingCopy = (resp) => {
+    const addRollbackToHistory = (resp) => {
       activity.appendRollback("WorkingCopyRollback", (onRollback) => {
         core.destroy({uid: resp.id}, onRollback);
       });
@@ -78,12 +78,12 @@ class SpatialService {
 
     if (layer.uid === Layer.EMPTY) {
       return core.create(activity.view, layer, (err, resp) => {
-        if(!err) rollbackWorkingCopy(resp);
+        if(!err) addRollbackToHistory(resp);
         cb(err, [resp, false]);
       });
     }
     return core.replace(layer, (err, resp) => {
-        if(!err) rollbackWorkingCopy(resp);
+        if(!err) addRollbackToHistory(resp);
         cb(err, [resp, true]);
     });
   }

--- a/es6-test/services/mock-core.js
+++ b/es6-test/services/mock-core.js
@@ -32,6 +32,8 @@ const view = (name) => ({
   "id": "qs32-qpt7",
   "name": name,
   "averageRating": 0,
+  "blobId": "qs32-blob-id",
+  "blobFilename": "foo.zip",
   "createdAt": 1446152737,
   "downloadCount": 0,
   "newBackend": false,
@@ -236,6 +238,10 @@ class CoreMock {
     app.put('/views/:fourfour', function(req, res) {
       this._history.push(req);
 
+      if (this.failSetBlob && req.query.method === 'setBlob') {
+        return res.status(this.failSetBlob).send('failSetBlob');
+      }
+
       req.bufferedRows = '';
       req.pipe(es.map((thing, cb) => {
         req.bufferedRows += thing.toString('utf-8');
@@ -267,6 +273,23 @@ class CoreMock {
       const absPath = path.resolve(`${__dirname}/../fixtures/${req.params.blobId}`);
       res.sendFile(absPath);
     });
+
+    app.put('/id/:fourfour', function(req, res) {
+      this._history.push(req);
+
+      if (this.failUpsert) {
+        return res.status(this.failUpsert).send('failUpsert');
+      }
+
+      req.bufferedRows = '';
+      req.pipe(es.map((thing, cb) => {
+        req.bufferedRows += thing.toString('utf-8');
+      }));
+
+      req.on('end', () => {
+        res.status(200).send('{}');
+      });
+    }.bind(this));
 
     this._app = app.listen(port);
   }

--- a/es6-test/unit/core-client.js
+++ b/es6-test/unit/core-client.js
@@ -179,74 +179,26 @@ describe('core client', function() {
     const auth = new Auth(parseAMQMessage(message));
     var core = new Core(auth, mockZk, NoopLogger);
 
-    const layers = [{
-      "bbox": {
-        "maxx": 102,
-        "maxy": 0.5,
-        "minx": 102,
-        "miny": 0.5
-      },
-      "columns": [
-        {
-          "dataTypeName": "multipoint",
-          "fieldName": "the_geom",
-          "name": "the_geom"
-        },
-        {
-          "dataTypeName": "text",
-          "fieldName": "a_string",
-          "name": "a_string"
-        }
-      ],
-      "uid": "aaaa-aaaa",
-      "count": 1,
-      "geometry": "multipoint",
-      "name": "some points",
-      "projection": "WGS 84"
-    },
-    {
-      "bbox": {
-        "maxx": 101,
-        "maxy": 1,
-        "minx": 101,
-        "miny": 0
-      },
-      "columns": [
-        {
-          "dataTypeName": "multiline",
-          "fieldName": "the_geom",
-          "name": "the_geom"
-        },
-        {
-          "dataTypeName": "text",
-          "fieldName": "a_string",
-          "name": "a_string"
-        }
-      ],
-      "uid": "bbbb-bbbb",
-      "count": 1,
-      "geometry": "multiline",
-      "name": "some lines",
-      "projection": "WGS 84"
+    const metadata = {
+      foo: 1,
+      bar: 'baz'
     }
-  ]
-    const bbox = JSON.stringify({"minx":101,"miny":0,"maxx":102,"maxy":1})
+    const privateMetadata = {
+      secret: 'metadata'
+    }
 
-    core.updateMetadata('four-four', layers, bbox, (err, res) => {
+
+    core.updateMetadata('four-four', metadata, privateMetadata, (err, res) => {
       expect(res).to.deep.eql({
         displayType: 'map',
         metadata: {
-          geo: {
-            owsUrl: '/api/geospatial/four-four',
-            layers: 'aaaa-aaaa,bbbb-bbbb',
-            isNbe: true,
-            bboxCrs: 'EPSG:4326',
-            namespace: '_four-four',
-            featureIdAttribute: '_SocrataID',
-            bbox: '{"minx":101,"miny":0,"maxx":102,"maxy":1}'
+          foo: 1,
+          bar: 'baz'
+        },
+        privateMetadata: {
+          secret: 'metadata'
         }
-      },
-      privateMetadata: { foo: 'bar', childViews: [ 'aaaa-aaaa', 'bbbb-bbbb' ] } })
+      })
       onDone();
     });
   });

--- a/es6-test/unit/spatial.js
+++ b/es6-test/unit/spatial.js
@@ -644,8 +644,6 @@ describe('spatial service', function() {
         replacingUid: 'qs32-qpt7'
       }],
     );
-
-    // mockAmq.importFixture('simple_points.kmz', ['bar'], 'qs32-qpt7');
   });
 
   it('will give a 400 on complex shapes', function(onDone) {


### PR DESCRIPTION
* Re-work of how rollbacks happen.
  * Each step adds a callback which will undo itself
  * on an error, all those callbacks are executed in serial
* Publication now happens at the end. This can
  still lead to broken views, but imo broken in a less
  bad way.
* Actually fix the bug, which was that blobId wasn't set.
  This used to happen in freezer, now needs to happen
  here.