### PR TITLE
EN-10642 Rework how crs's work

### DIFF
--- a/es6-lib/config/config.js
+++ b/es6-lib/config/config.js
@@ -21,7 +21,7 @@ default {
   upstreamTimeoutMs: 2 * 60 * 1000,
 
   //number of rows to buffer in object mode feature streams
-  rowBufferSize: 2,
+  rowBufferSize: 20,
 
   //maximum number of points to allow through the importer per row
   maxVerticesPerRow: 1000000,

--- a/es6-lib/decoders/wgs84-reprojector.js
+++ b/es6-lib/decoders/wgs84-reprojector.js
@@ -30,6 +30,10 @@ class WGS84Reprojector extends Transform {
     return this._projectTo;
   }
 
+  get projectionString() {
+    return WGS84;
+  }
+
   get bbox() {
     return this._bbox;
   }

--- a/es6-test/fixtures/simple_lines.json
+++ b/es6-test/fixtures/simple_lines.json
@@ -18,12 +18,6 @@
       "type": "Feature",
       "properties": {
         "a_string": "first value"
-      },
-      "crs": {
-        "type": "name",
-        "properties": {
-          "name": "urn:ogc:def:crs:EPSG::26915"
-        }
       }
     },
     {

--- a/es6-test/fixtures/simple_multilines.json
+++ b/es6-test/fixtures/simple_multilines.json
@@ -12,12 +12,6 @@
       "type": "Feature",
       "properties": {
         "a_string": "first value"
-      },
-      "crs": {
-        "type": "name",
-        "properties": {
-          "name": "urn:ogc:def:crs:EPSG::26915"
-        }
       }
     },
     {

--- a/es6-test/fixtures/simple_multipoints.json
+++ b/es6-test/fixtures/simple_multipoints.json
@@ -10,12 +10,6 @@
       "type": "Feature",
       "properties": {
         "a_string": "first value"
-      },
-      "crs": {
-        "type": "name",
-        "properties": {
-          "name": "urn:ogc:def:crs:EPSG::26915"
-        }
       }
     },
     {

--- a/es6-test/fixtures/simple_multipolygons.json
+++ b/es6-test/fixtures/simple_multipolygons.json
@@ -14,12 +14,6 @@
       "type": "Feature",
       "properties": {
         "a_string": "first value"
-      },
-      "crs": {
-        "type": "name",
-        "properties": {
-          "name": "urn:ogc:def:crs:EPSG::26915"
-        }
       }
     },
     {

--- a/es6-test/fixtures/simple_polygons.json
+++ b/es6-test/fixtures/simple_polygons.json
@@ -13,12 +13,6 @@
       "type": "Feature",
       "properties": {
         "a_string": "first value"
-      },
-      "crs": {
-        "type": "name",
-        "properties": {
-          "name": "urn:ogc:def:crs:EPSG::26915"
-        }
       }
     },
     {

--- a/es6-test/smoke/flow-control.js
+++ b/es6-test/smoke/flow-control.js
@@ -21,6 +21,7 @@ import KML from '../../es6-lib/decoders/kml';
 import GeoJSON from '../../es6-lib/decoders/geojson';
 import Merger from '../../es6-lib/decoders/merger';
 import Disk from '../../es6-lib/decoders/disk';
+
 import {
   Transform
 }
@@ -226,37 +227,6 @@ describe('flow control', () => {
         });
       });
   });
-
-
-  // it('edmonton will not overwhelm merger stream consumer', function(onDone) {
-  //   this.timeout(100000);
-  //   var count = 0;
-
-  //   var res = new EventEmitter();
-  //   var disk = new Disk(res, NoopLogger);
-
-  //   var decoder = new Shapefile(disk);
-  //   var merger = new Merger(disk, [], false, NoopLogger);
-
-  //   fixture('smoke/edmonton.zip')
-  //     .pipe(decoder)
-  //     // .pipe(merger)
-  //     .on('end', (layers) => {
-  //       console.log("layers", layers)
-  //       // layers.map((layer) => {
-  //       //   layer
-  //       //     .pipe(new SlowConsumer())
-  //       //     .pipe(es.mapSync((thing) => {
-  //       //       expect(layer._readableState.length).to.be.at.most(20000);
-  //       //       return thing;
-  //       //     }))
-  //       //     .on('end', () => {
-  //       //       res.emit('finish');
-  //       //       onDone();
-  //       //     });
-  //       // });
-  //     });
-  // });
 
   it('will stop flowing when a layer consumer is unpiped', function(onDone) {
     //for jankins

--- a/es6-test/unit/merger.js
+++ b/es6-test/unit/merger.js
@@ -157,7 +157,7 @@ describe('merging feature streams to layers', function() {
   });
 
 
-  it('will handle homogenous points, homogenous crs', function(onDone) {
+  it('will handle homogenous points, heterogenous crs', function(onDone) {
     var [merger, response] = makeMerger();
 
     fixture('multi_crs.json')

--- a/es6-test/unit/merger.js
+++ b/es6-test/unit/merger.js
@@ -60,7 +60,7 @@ function jsbuf() {
   });
 }
 
-
+const FLOAT_DELTA = .000000001;
 
 describe('merging feature streams to layers', function() {
 
@@ -69,6 +69,7 @@ describe('merging feature streams to layers', function() {
     fixture('simple_points.json')
       .pipe(new GeoJSON())
       .pipe(merger)
+      .on('error', (e) => console.error(e))
       .on('end', (layers) => {
         response.emit('finish');
         expect(layers.length).to.equal(1);
@@ -123,46 +124,40 @@ describe('merging feature streams to layers', function() {
       .pipe(merger)
       .on('end', (layers) => {
 
-        expect(layers.length).to.equal(1);
+        expect(layers.length).to.equal(2);
 
-        var [layer] = layers;
-
-        expect(layer.columns.map(c => [c.name, c.ctype])).to.eql([
+        const expectedColumns = [
           ['the_geom', 'point'],
           ['a_string', 'string'],
           ['a_num', 'number'],
           ['a_float', 'number'],
           ['a_bool', 'boolean']
-        ]);
+        ];
 
+        layers.forEach(layer => {
+          expect(layer.columns.map(c => [c.name, c.ctype])).to.eql(expectedColumns);
+        });
 
-        layer.pipe(jsbuf()).on('end', function(jsRow) {
-          expect(jsRow).to.eql([{
-            "the_geom": {
-              "type": "Point",
-              "coordinates": [-97.48783007891072, 0.000004509692825832316]
-            },
-            "a_string": "first value",
-            "a_num": 2,
-            "a_float": 2.2,
-            "a_bool": false
-          }, {
-            "the_geom": {
-              "type": "Point",
-              "coordinates": [10.788967390468883, 45.03596703206463]
-            },
-            "a_string": "second value",
-            "a_num": 2,
-            "a_float": 2.2,
-            "a_bool": true
-          }]);
-          onDone();
+        var [epsg26915, epsg23700] = layers;
+
+        epsg26915.pipe(jsbuf()).on('end', ([row]) => {
+          var [x, y] = row.the_geom.coordinates
+          expect(x).to.be.closeTo(-97.48783007892, FLOAT_DELTA);
+          expect(y).to.be.closeTo(0.00000450965,  FLOAT_DELTA);
+
+          epsg23700.pipe(jsbuf()).on('end', ([row]) => {
+
+            var [x, y] = row.the_geom.coordinates
+            expect(x).to.be.closeTo(10.7889673904, FLOAT_DELTA);
+            expect(y).to.be.closeTo(45.0359670320,  FLOAT_DELTA);
+            onDone();
+          });
         });
       });
   });
 
 
-  it('will handle homogenous points, heterogenous crs', function(onDone) {
+  it('will handle homogenous points, homogenous crs', function(onDone) {
     var [merger, response] = makeMerger();
 
     fixture('multi_crs.json')
@@ -170,46 +165,38 @@ describe('merging feature streams to layers', function() {
       .pipe(merger)
       .on('end', (layers) => {
 
-        expect(layers.length).to.equal(1);
+        expect(layers.length).to.equal(2);
 
-        var [layer] = layers;
+        layers.forEach(layer => {
+          expect(layer.columns.map(c => [c.name, c.ctype])).to.eql([
+            ['the_geom', 'point'],
+            ['a_string', 'string'],
+            ['a_num', 'number'],
+            ['a_float', 'number'],
+            ['a_bool', 'boolean']
+          ]);
+        });
 
-        expect(layer.columns.map(c => [c.name, c.ctype])).to.eql([
-          ['the_geom', 'point'],
-          ['a_string', 'string'],
-          ['a_num', 'number'],
-          ['a_float', 'number'],
-          ['a_bool', 'boolean']
-        ]);
+        var [epsg26915, crs84] = layers;
 
+        epsg26915.pipe(jsbuf()).on('end', ([row]) => {
 
-        layer.pipe(jsbuf()).on('end', (jsRow) => {
-          expect(jsRow).to.eql([{
-            "the_geom": {
-              "type": "Point",
-              "coordinates": [-97.48783007891072, 0.000004509692825832316]
-            },
-            "a_string": "first value",
-            "a_num": 2,
-            "a_float": 2.2,
-            "a_bool": false
-          }, {
-            "the_geom": {
-              "type": "Point",
-              "coordinates": [103, 1.5]
-            },
-            "a_string": "second value",
-            "a_num": 2,
-            "a_float": 2.2,
-            "a_bool": true
-          }]);
-          onDone();
+          var [x, y] = row.the_geom.coordinates
+          expect(x).to.be.closeTo(-97.48783007891072, FLOAT_DELTA);
+          expect(y).to.be.closeTo(  0.00000450969282, FLOAT_DELTA);
+
+          crs84.pipe(jsbuf()).on('end', ([row]) => {
+            var [x, y] = row.the_geom.coordinates
+            expect(x).to.be.closeTo(103, FLOAT_DELTA);
+            expect(y).to.be.closeTo(1.5, FLOAT_DELTA);
+            onDone();
+          });
         });
       });
   });
 
 
-  it('will handle homogenous lines, heterogenous crs', function(onDone) {
+  it('will handle homogenous lines, homogenous crs', function(onDone) {
     var [merger, response] = makeMerger();
 
     fixture('simple_lines.json')
@@ -232,8 +219,8 @@ describe('merging feature streams to layers', function() {
             "the_geom": {
               "type": "LineString",
               "coordinates": [
-                [-97.48784799692679, 0],
-                [-97.48783903791886, 0.000009019385540221545]
+                [100, 0],
+                [101, 1]
               ]
             },
             "a_string": "first value"
@@ -253,7 +240,7 @@ describe('merging feature streams to layers', function() {
   });
 
 
-  it('will handle homogenous polygons, heterogenous crs', function(onDone) {
+  it('will handle homogenous polygons, homogenous crs', function(onDone) {
     var [merger, response] = makeMerger();
     fixture('simple_polygons.json')
       .pipe(new GeoJSON())
@@ -275,20 +262,8 @@ describe('merging feature streams to layers', function() {
             "the_geom": {
               "type": "Polygon",
               "coordinates": [
-                [
-                  [-97.48784799692679, 0],
-                  [-97.4878390379188, 0],
-                  [-97.48783903791886, 0.000009019385540221545],
-                  [-97.48784799692685, 0.000009019385428778238],
-                  [-97.48784799692679, 0]
-                ],
-                [
-                  [-97.48784620512521, 0.0000018038770902133842],
-                  [-97.48784082972041, 0.000001803877103586581],
-                  [-97.48784082972045, 0.000007215508414346324],
-                  [-97.48784620512522, 0.000007215508360853537],
-                  [-97.48784620512521, 0.0000018038770902133842]
-                ]
+                [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
+                [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
               ]
             },
             "a_string": "first value"
@@ -320,7 +295,7 @@ describe('merging feature streams to layers', function() {
   });
 
 
-  it('will handle homogenous multipoints, heterogenous crs', function(onDone) {
+  it('will handle homogenous multipoints, homogenous crs', function(onDone) {
     var [merger, response] = makeMerger();
 
     fixture('simple_multipoints.json')
@@ -342,10 +317,7 @@ describe('merging feature streams to layers', function() {
           expect(jsRow).to.eql([{
             "the_geom": {
               "type": "MultiPoint",
-              "coordinates": [
-                [-97.48784799692679, 0],
-                [-97.48783903791886, 0.000009019385540221545]
-              ]
+              "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
             },
             "a_string": "first value"
           }, {
@@ -387,22 +359,8 @@ describe('merging feature streams to layers', function() {
             "the_geom": {
               "type": "MultiLineString",
               "coordinates": [
-                [
-                  [-97.48784799692679,
-                    0
-                  ],
-                  [-97.48783903791886,
-                    0.000009019385540221545
-                  ]
-                ],
-                [
-                  [-97.48783007891092,
-                    0.000018038771303329256
-                  ],
-                  [-97.48782111990299,
-                    0.000027058157289322467
-                  ]
-                ]
+                [ [100.0, 0.0], [101.0, 1.0] ],
+                [ [102.0, 2.0], [103.0, 3.0] ]
               ]
             },
             "a_string": "first value"
@@ -410,26 +368,8 @@ describe('merging feature streams to layers', function() {
             "the_geom": {
               "type": "MultiLineString",
               "coordinates": [
-                [
-                  [
-                    101,
-                    0
-                  ],
-                  [
-                    102,
-                    1
-                  ]
-                ],
-                [
-                  [
-                    102,
-                    2
-                  ],
-                  [
-                    103,
-                    3
-                  ]
-                ]
+                [ [101.0, 0.0], [102.0, 1.0] ],
+                [ [102.0, 2.0], [103.0, 3.0] ]
               ]
             },
             "a_string": "second value"
@@ -464,61 +404,9 @@ describe('merging feature streams to layers', function() {
             "the_geom": {
               "type": "MultiPolygon",
               "coordinates": [
-                [
-                  [
-                    [-97.48783007891092,
-                      0.000018038771303329256
-                    ],
-                    [-97.48782111990273,
-                      0.00001803877152621498
-                    ],
-                    [-97.48782111990299,
-                      0.000027058157289322467
-                    ],
-                    [-97.4878300789112,
-                      0.00002705815695499387
-                    ],
-                    [-97.48783007891092,
-                      0.000018038771303329256
-                    ]
-                  ]
-                ],
-                [
-                  [
-                    [-97.48784799692679,
-                      0
-                    ],
-                    [-97.4878390379188,
-                      0
-                    ],
-                    [-97.48783903791886,
-                      0.000009019385540221545
-                    ],
-                    [-97.48784799692685,
-                      0.000009019385428778238
-                    ],
-                    [-97.48784799692679,
-                      0
-                    ]
-                  ],
-                  [
-                    [-97.48784620512521,
-                      0.0000018038770902133842
-                    ],
-                    [-97.48784082972041,
-                      0.000001803877103586581
-                    ],
-                    [-97.48784082972045,
-                      0.000007215508414346324
-                    ],
-                    [-97.48784620512522,
-                      0.000007215508360853537
-                    ],
-                    [-97.48784620512521,
-                      0.0000018038770902133842
-                    ]
-                  ]
-                ]
+                [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+                [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+                 [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
               ]
             },
             "a_string": "first value"
@@ -526,77 +414,10 @@ describe('merging feature streams to layers', function() {
             "the_geom": {
               "type": "MultiPolygon",
               "coordinates": [
-                [
-                  [
-                    [
-                      103,
-                      2
-                    ],
-                    [
-                      102,
-                      2
-                    ],
-                    [
-                      103,
-                      3
-                    ],
-                    [
-                      102,
-                      3
-                    ],
-                    [
-                      103,
-                      2
-                    ]
-                  ]
-                ],
-                [
-                  [
-                    [
-                      100,
-                      0
-                    ],
-                    [
-                      101,
-                      0
-                    ],
-                    [
-                      101,
-                      1
-                    ],
-                    [
-                      100,
-                      1
-                    ],
-                    [
-                      100,
-                      0
-                    ]
-                  ],
-                  [
-                    [
-                      100.2,
-                      0.2
-                    ],
-                    [
-                      100.8,
-                      0.2
-                    ],
-                    [
-                      100.8,
-                      0.8
-                    ],
-                    [
-                      100.2,
-                      0.8
-                    ],
-                    [
-                      100.2,
-                      0.2
-                    ]
-                  ]
+                [[[103.0, 2.0], [102.0, 2.0], [103.0, 3.0], [102.0, 3.0], [103.0, 2.0]]],
+                [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+                 [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
                 ]
-              ]
             },
             "a_string": "second value"
           }]);


### PR DESCRIPTION
* Now rows with different CRSs get put in different layers.
  This means we don't have to store each CRS+offset in each layer,
  because layers have a single CRS.
* The original bug was for a 3million row dataset it would
  allocate 3m CRS strings, which would kill the service
* Reworked tests as well
  * have hetero/homogenous CRS layers in the merger unit test,
    changed expectations of how many layers will be made
  * made floating point checks not gross - wasn't causing problems
    in practice but it's much nicer now.