### PR TITLE
EN-12855 Empty coordinate lists were breaking things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-lib: es6-lib node_modules node_modules/node-srs
+lib: es6-lib node_modules
 	mkdir -p lib
 	node_modules/.bin/babel es6-lib --out-dir lib
 
-test:
+test: lib
 	GEO_IMPORT_ENV=test ./node_modules/.bin/mocha es6-test/unit es6-test/smoke --compilers js:babel/register && jshint es6-lib
 
 appease_jenkins: lib
@@ -15,12 +15,6 @@ translations: lib
 node_modules:
 	npm set progress=false # this makes npm twice as fast ;_;
 	npm i
-
-node_modules/node-srs:
-	mkdir -p node_modules/node-srs
-	git clone https://github.com/rozap/node-srs node_modules/node-srs
-	cd node_modules/node-srs && CC=gcc CXX=g++ npm install && cd ../..
-	cd ../..
 
 clean:
 	rm -rf lib

--- a/es6-lib/decoders/layer.js
+++ b/es6-lib/decoders/layer.js
@@ -12,7 +12,7 @@ import {
   EventEmitter
 }
 from 'events';
-import srs from 'node-srs';
+import srs from 'srs';
 import BBox from '../util/bbox';
 import {
   Duplex

--- a/es6-lib/decoders/shapefile.js
+++ b/es6-lib/decoders/shapefile.js
@@ -23,7 +23,7 @@ import concat from 'concat-stream';
 import yauzl from 'yauzl';
 import path from 'path';
 import fs from 'fs';
-import srs from 'node-srs';
+import srs from 'srs';
 import uuid from 'uuid';
 import {
   EventEmitter

--- a/es6-lib/decoders/wgs84-reprojector.js
+++ b/es6-lib/decoders/wgs84-reprojector.js
@@ -8,7 +8,7 @@ import {
   types
 }
 from '../soql/mapper';
-import srs from 'node-srs';
+import srs from 'srs';
 import BBox from '../util/bbox';
 import {InvalidArityError} from '../errors';
 

--- a/es6-lib/services/spatial.js
+++ b/es6-lib/services/spatial.js
@@ -427,6 +427,15 @@ class SpatialService {
   }
 
   _onError(activity, reason) {
+    // Hack because everything about error handling/propagation in js
+    // is a dumpsterfire made up of smaller dumpsterfires
+    const getStackTrace = () => {
+        let stack = new Error().stack || '';
+        stack = stack.split('\n').map((line) => line.trim());
+        return stack.splice(stack[0] == 'Error' ? 2 : 1).join('\n');
+    };
+    activity.log.error(getStackTrace());
+
     activity.rollback(() => {
       activity.onError(reason);
       this._endProgress();

--- a/es6-lib/soql/geom.js
+++ b/es6-lib/soql/geom.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
 import proj4 from 'proj4';
 import SoQL from './soql';
-import * as srs from 'node-srs';
 
 class SoQLGeom extends SoQL {
   get isGeometry() {

--- a/es6-lib/util/bbox.js
+++ b/es6-lib/util/bbox.js
@@ -37,7 +37,11 @@ class BBox {
     return this._coords.miny;
   }
 
-  _isValid([x, y]) {
+  _isValid(coord) {
+    if (!coord) return false;
+    if (coord.length !== 2) return false;
+
+    const [x, y] = coord;
     var validMinX = x >= MIN_LONGITUDE;
     var validMaxX = x <= MAX_LONGITUDE;
 

--- a/es6-test/fixtures/empty_coords.json
+++ b/es6-test/fixtures/empty_coords.json
@@ -1,0 +1,34 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            100.0,
+            0.0
+          ],
+          [
+            101.0,
+            1.0
+          ]
+        ]
+      },
+      "type": "Feature",
+      "properties": {
+        "a_string": "first value"
+      }
+    },
+    {
+      "geometry": {
+        "type": "LineString",
+        "coordinates": []
+      },
+      "type": "Feature",
+      "properties": {
+        "a_string": "second value"
+      }
+    }
+  ]
+}

--- a/es6-test/unit/shapefile.js
+++ b/es6-test/unit/shapefile.js
@@ -6,7 +6,7 @@ import {
 }
 from '../fixture';
 import Shapefile from '../../es6-lib/decoders/shapefile';
-import srs from 'node-srs';
+import srs from 'srs';
 import Disk from '../../es6-lib/decoders/disk';
 import {
   EventEmitter

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ofe": "0.5.0",
     "gc-stats": "1.0.0",
     "deepmerge": "0.2.10",
-    "js-yaml": "3.6.1"
+    "js-yaml": "3.6.1",
+    "srs": "1.2.0"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
* Would get classified as a different layer
  * The actual fix is in the rozap/shapefile library,
    the same garbage that was happening with wrapping
    polygons as multis was happening to lines. The logic
    in the original library was bad so i changed it
* This then broke other things that assumed coordinates
  existed - i fixed those, and added a test
* Un c++ified the node-srs dep, because mapbox
  released a impl that just seems to work :yay: