### PR TITLE
Fix mocha to version 3.5.3 as the 4.0.0 version doesn't exit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "chai": "*",
-    "mocha": "*",
+    "mocha": "3.5.3",
     "jsonfile": "*",
     "prompt": "*",
     "should": "latest"


### PR DESCRIPTION
If this works, the PR builder should actually pass.