### PR TITLE
[noissue] use runit-nodejs-bionic-14x

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/runit-nodejs-bionic-10x
+FROM socrata/runit-nodejs-bionic-14x
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/nodejs=""


### PR DESCRIPTION
We are on node 14 so we shouldn't be using 10x anymore.