### PR TITLE
[EN-46576] upgrade npm and y18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2999,44 +2999,46 @@
       }
     },
     "npm": {
-      "version": "7.6.3",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/npm/-/npm-7.6.3.tgz",
-      "integrity": "sha1-KcBIuFIvyEavG2b7uM5/NWWEsSE=",
+      "version": "7.20.0",
+      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/npm/-/npm-7.20.0.tgz",
+      "integrity": "sha1-BueSR8iDbL0d7gemvDgNtiT4nFs=",
       "requires": {
-        "@npmcli/arborist": "^2.2.8",
+        "@npmcli/arborist": "^2.7.1",
         "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^1.2.9",
-        "@npmcli/run-script": "^1.8.3",
+        "@npmcli/config": "^2.2.0",
+        "@npmcli/package-json": "^1.0.1",
+        "@npmcli/run-script": "^1.8.5",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
         "archy": "~1.0.0",
         "byte-size": "^7.0.1",
-        "cacache": "^15.0.5",
+        "cacache": "^15.2.0",
         "chalk": "^4.1.0",
         "chownr": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.6.0",
         "columnify": "~1.5.4",
-        "glob": "^7.1.4",
+        "glob": "^7.1.7",
         "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^3.0.8",
+        "hosted-git-info": "^4.0.2",
         "ini": "^2.0.0",
-        "init-package-json": "^2.0.2",
+        "init-package-json": "^2.0.3",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
         "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.1",
+        "libnpmaccess": "^4.0.2",
         "libnpmdiff": "^2.0.4",
-        "libnpmfund": "^1.0.2",
-        "libnpmhook": "^6.0.1",
-        "libnpmorg": "^2.0.1",
+        "libnpmexec": "^2.0.0",
+        "libnpmfund": "^1.1.0",
+        "libnpmhook": "^6.0.2",
+        "libnpmorg": "^2.0.2",
         "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.0",
-        "libnpmsearch": "^3.1.0",
-        "libnpmteam": "^2.0.2",
-        "libnpmversion": "^1.0.11",
-        "make-fetch-happen": "^8.0.14",
+        "libnpmpublish": "^4.0.1",
+        "libnpmsearch": "^3.1.1",
+        "libnpmteam": "^2.0.3",
+        "libnpmversion": "^1.2.1",
+        "make-fetch-happen": "^9.0.4",
         "minipass": "^3.1.3",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
@@ -3044,15 +3046,15 @@
         "ms": "^2.1.2",
         "node-gyp": "^7.1.2",
         "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.4",
-        "npm-package-arg": "^8.1.1",
-        "npm-pick-manifest": "^6.1.0",
-        "npm-profile": "^5.0.2",
-        "npm-registry-fetch": "^9.0.0",
+        "npm-audit-report": "^2.1.5",
+        "npm-package-arg": "^8.1.5",
+        "npm-pick-manifest": "^6.1.1",
+        "npm-profile": "^5.0.3",
+        "npm-registry-fetch": "^11.0.0",
         "npm-user-validate": "^1.0.1",
         "npmlog": "~4.1.2",
         "opener": "^1.5.2",
-        "pacote": "^11.3.0",
+        "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
@@ -3060,7 +3062,7 @@
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.4",
+        "semver": "^7.3.5",
         "ssri": "^8.0.1",
         "tar": "^6.1.0",
         "text-table": "~0.2.0",
@@ -3072,7 +3074,7 @@
       },
       "dependencies": {
         "@npmcli/arborist": {
-          "version": "2.2.8",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
             "@npmcli/installed-package-contents": "^1.0.7",
@@ -3081,24 +3083,29 @@
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
             "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/package-json": "^1.0.1",
             "@npmcli/run-script": "^1.8.2",
             "bin-links": "^2.2.1",
             "cacache": "^15.0.3",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
-            "json-stringify-nice": "^1.1.1",
+            "json-stringify-nice": "^1.1.4",
+            "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-install-checks": "^4.0.0",
             "npm-package-arg": "^8.1.0",
             "npm-pick-manifest": "^6.1.0",
-            "npm-registry-fetch": "^9.0.0",
+            "npm-registry-fetch": "^11.0.0",
             "pacote": "^11.2.6",
             "parse-conflict-json": "^1.1.1",
+            "proc-log": "^1.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
-            "semver": "^7.3.4",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.5",
+            "ssri": "^8.0.1",
             "tar": "^6.1.0",
             "treeverse": "^1.0.4",
             "walk-up-path": "^1.0.0"
@@ -3109,7 +3116,7 @@
           "bundled": true
         },
         "@npmcli/config": {
-          "version": "1.2.9",
+          "version": "2.2.0",
           "bundled": true,
           "requires": {
             "ini": "^2.0.0",
@@ -3127,17 +3134,16 @@
           }
         },
         "@npmcli/git": {
-          "version": "2.0.6",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "@npmcli/promise-spawn": "^1.1.0",
+            "@npmcli/promise-spawn": "^1.3.2",
             "lru-cache": "^6.0.0",
-            "mkdirp": "^1.0.3",
-            "npm-pick-manifest": "^6.0.0",
+            "mkdirp": "^1.0.4",
+            "npm-pick-manifest": "^6.1.1",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
-            "semver": "^7.3.2",
-            "unique-filename": "^1.1.1",
+            "semver": "^7.3.5",
             "which": "^2.0.2"
           }
         },
@@ -3160,7 +3166,7 @@
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "cacache": "^15.0.5",
@@ -3184,6 +3190,13 @@
           "version": "1.0.2",
           "bundled": true
         },
+        "@npmcli/package-json": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.1"
+          }
+        },
         "@npmcli/promise-spawn": {
           "version": "1.3.2",
           "bundled": true,
@@ -3192,14 +3205,13 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.3",
+          "version": "1.8.5",
           "bundled": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
             "infer-owner": "^1.0.4",
             "node-gyp": "^7.1.0",
-            "puka": "^1.0.1",
             "read-package-json-fast": "^2.0.1"
           }
         },
@@ -3308,7 +3320,7 @@
           "bundled": true
         },
         "balanced-match": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true
         },
         "bcrypt-pbkdf": {
@@ -3351,7 +3363,7 @@
           "bundled": true
         },
         "cacache": {
-          "version": "15.0.5",
+          "version": "15.2.0",
           "bundled": true,
           "requires": {
             "@npmcli/move-file": "^1.0.1",
@@ -3368,7 +3380,7 @@
             "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^3.0.2",
-            "ssri": "^8.0.0",
+            "ssri": "^8.0.1",
             "tar": "^6.0.2",
             "unique-filename": "^1.1.1"
           }
@@ -3378,7 +3390,7 @@
           "bundled": true
         },
         "chalk": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3426,7 +3438,7 @@
               "bundled": true
             },
             "string-width": {
-              "version": "4.2.0",
+              "version": "4.2.2",
               "bundled": true,
               "requires": {
                 "emoji-regex": "^8.0.0",
@@ -3581,7 +3593,7 @@
           }
         },
         "env-paths": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true
         },
         "err-code": {
@@ -3607,15 +3619,6 @@
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
         },
         "fs-minipass": {
           "version": "2.1.0",
@@ -3676,7 +3679,7 @@
           }
         },
         "glob": {
-          "version": "7.1.6",
+          "version": "7.1.7",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3719,7 +3722,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "3.0.8",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -3763,7 +3766,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.6.2",
+          "version": "0.6.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3771,7 +3774,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -3806,15 +3809,15 @@
           "bundled": true
         },
         "init-package-json": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
             "glob": "^7.1.1",
-            "npm-package-arg": "^8.1.0",
+            "npm-package-arg": "^8.1.2",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "^3.0.0",
-            "semver": "^7.3.2",
+            "read-package-json": "^3.0.1",
+            "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
           }
@@ -3835,7 +3838,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.2.0",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
             "has": "^1.0.3"
@@ -3882,7 +3885,7 @@
           "bundled": true
         },
         "json-stringify-nice": {
-          "version": "1.1.1",
+          "version": "1.1.4",
           "bundled": true
         },
         "json-stringify-safe": {
@@ -3904,7 +3907,7 @@
           }
         },
         "just-diff": {
-          "version": "3.0.2",
+          "version": "3.1.1",
           "bundled": true
         },
         "just-diff-apply": {
@@ -3916,13 +3919,13 @@
           "bundled": true
         },
         "libnpmaccess": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
-            "npm-package-arg": "^8.0.0",
-            "npm-registry-fetch": "^9.0.0"
+            "npm-package-arg": "^8.1.2",
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmdiff": {
@@ -3934,32 +3937,49 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.1",
-            "pacote": "^11.3.0",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
             "tar": "^6.1.0"
           }
         },
-        "libnpmfund": {
-          "version": "1.0.2",
+        "libnpmexec": {
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^2.0.0"
+            "@npmcli/arborist": "^2.3.0",
+            "@npmcli/ci-detect": "^1.3.0",
+            "@npmcli/run-script": "^1.8.4",
+            "chalk": "^4.1.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-package-arg": "^8.1.2",
+            "pacote": "^11.3.1",
+            "proc-log": "^1.0.0",
+            "read": "^1.0.7",
+            "read-package-json-fast": "^2.0.2",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "libnpmfund": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "@npmcli/arborist": "^2.5.0"
           }
         },
         "libnpmhook": {
-          "version": "6.0.1",
+          "version": "6.0.3",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^9.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmorg": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^9.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmpack": {
@@ -3972,39 +3992,39 @@
           }
         },
         "libnpmpublish": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
-            "normalize-package-data": "^3.0.0",
-            "npm-package-arg": "^8.1.0",
-            "npm-registry-fetch": "^9.0.0",
+            "normalize-package-data": "^3.0.2",
+            "npm-package-arg": "^8.1.2",
+            "npm-registry-fetch": "^11.0.0",
             "semver": "^7.1.3",
-            "ssri": "^8.0.0"
+            "ssri": "^8.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "3.1.0",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "npm-registry-fetch": "^9.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmteam": {
-          "version": "2.0.2",
+          "version": "2.0.4",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^9.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmversion": {
-          "version": "1.0.11",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "@npmcli/git": "^2.0.6",
-            "@npmcli/run-script": "^1.8.3",
-            "read-package-json-fast": "^2.0.1",
-            "semver": "^7.3.4",
+            "@npmcli/git": "^2.0.7",
+            "@npmcli/run-script": "^1.8.4",
+            "json-parse-even-better-errors": "^2.3.1",
+            "semver": "^7.3.5",
             "stringify-package": "^1.0.1"
           }
         },
@@ -4016,11 +4036,11 @@
           }
         },
         "make-fetch-happen": {
-          "version": "8.0.14",
+          "version": "9.0.4",
           "bundled": true,
           "requires": {
             "agentkeepalive": "^4.1.3",
-            "cacache": "^15.0.5",
+            "cacache": "^15.2.0",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^4.0.1",
             "https-proxy-agent": "^5.0.0",
@@ -4031,20 +4051,21 @@
             "minipass-fetch": "^1.3.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.2",
             "promise-retry": "^2.0.1",
             "socks-proxy-agent": "^5.0.0",
             "ssri": "^8.0.0"
           }
         },
         "mime-db": {
-          "version": "1.45.0",
+          "version": "1.48.0",
           "bundled": true
         },
         "mime-types": {
-          "version": "2.1.28",
+          "version": "2.1.31",
           "bundled": true,
           "requires": {
-            "mime-db": "1.45.0"
+            "mime-db": "1.48.0"
           }
         },
         "minimatch": {
@@ -4069,7 +4090,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.3.3",
+          "version": "1.3.4",
           "bundled": true,
           "requires": {
             "encoding": "^0.1.12",
@@ -4136,6 +4157,10 @@
           "version": "0.0.8",
           "bundled": true
         },
+        "negotiator": {
+          "version": "0.6.2",
+          "bundled": true
+        },
         "node-gyp": {
           "version": "7.1.2",
           "bundled": true,
@@ -4160,24 +4185,24 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^3.0.6",
-            "resolve": "^1.17.0",
-            "semver": "^7.3.2",
+            "hosted-git-info": "^4.0.1",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
         },
         "npm-audit-report": {
-          "version": "2.1.4",
+          "version": "2.1.5",
           "bundled": true,
           "requires": {
             "chalk": "^4.0.0"
           }
         },
         "npm-bundled": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -4195,16 +4220,16 @@
           "bundled": true
         },
         "npm-package-arg": {
-          "version": "8.1.1",
+          "version": "8.1.5",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^3.0.6",
-            "semver": "^7.0.0",
+            "hosted-git-info": "^4.0.1",
+            "semver": "^7.3.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "2.1.4",
+          "version": "2.2.2",
           "bundled": true,
           "requires": {
             "glob": "^7.1.6",
@@ -4214,28 +4239,27 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "requires": {
             "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.0.0",
-            "semver": "^7.0.0"
+            "npm-normalize-package-bin": "^1.0.1",
+            "npm-package-arg": "^8.1.2",
+            "semver": "^7.3.4"
           }
         },
         "npm-profile": {
-          "version": "5.0.2",
+          "version": "5.0.4",
           "bundled": true,
           "requires": {
-            "npm-registry-fetch": "^9.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "9.0.0",
+          "version": "11.0.0",
           "bundled": true,
           "requires": {
-            "@npmcli/ci-detect": "^1.0.0",
-            "lru-cache": "^6.0.0",
-            "make-fetch-happen": "^8.0.9",
+            "make-fetch-happen": "^9.0.1",
             "minipass": "^3.1.3",
             "minipass-fetch": "^1.3.0",
             "minipass-json-stream": "^1.0.1",
@@ -4288,10 +4312,10 @@
           }
         },
         "pacote": {
-          "version": "11.3.0",
+          "version": "11.3.5",
           "bundled": true,
           "requires": {
-            "@npmcli/git": "^2.0.1",
+            "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
             "@npmcli/promise-spawn": "^1.2.0",
             "@npmcli/run-script": "^1.8.2",
@@ -4304,7 +4328,7 @@
             "npm-package-arg": "^8.0.1",
             "npm-packlist": "^2.1.4",
             "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^9.0.0",
+            "npm-registry-fetch": "^11.0.0",
             "promise-retry": "^2.0.1",
             "read-package-json-fast": "^2.0.1",
             "rimraf": "^3.0.2",
@@ -4326,11 +4350,15 @@
           "bundled": true
         },
         "path-parse": {
-          "version": "1.0.6",
+          "version": "1.0.7",
           "bundled": true
         },
         "performance-now": {
           "version": "2.1.0",
+          "bundled": true
+        },
+        "proc-log": {
+          "version": "1.0.0",
           "bundled": true
         },
         "process-nextick-args": {
@@ -4366,10 +4394,6 @@
         },
         "psl": {
           "version": "1.8.0",
-          "bundled": true
-        },
-        "puka": {
-          "version": "1.0.1",
           "bundled": true
         },
         "punycode": {
@@ -4462,6 +4486,15 @@
             "uuid": "^3.3.2"
           },
           "dependencies": {
+            "form-data": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+              }
+            },
             "tough-cookie": {
               "version": "2.5.0",
               "bundled": true,
@@ -4500,7 +4533,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.3.4",
+          "version": "7.3.5",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4519,7 +4552,7 @@
           "bundled": true
         },
         "socks": {
-          "version": "2.5.1",
+          "version": "2.6.1",
           "bundled": true,
           "requires": {
             "ip": "^1.1.5",
@@ -4556,7 +4589,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.7",
+          "version": "3.0.9",
           "bundled": true
         },
         "sshpk": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "negotiator": "0.6.1",
     "node-expat": "2.3.18",
     "node-zookeeper-client": "0.2.2",
-    "npm": "7.6.3",
+    "npm": "7.20.0",
     "proj4": "2.3.12",
     "request": "2.88.2",
     "set-value": "2.0.1",


### PR DESCRIPTION
Upgrade npm to 7.20.0, which as a by-product will upgrade y18n as well.